### PR TITLE
Improve logging helper robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # mcxTemplate
 Templating engine for distro installations
+
+## Logging helpers
+The shell helpers in `common/lib/common.sh` expose timestamped logging functions
+(`mcx_log_info`, `mcx_log_warn`, and `mcx_log_error`). Console output always
+remains enabled so operators continue to see status messages even when file
+logging is turned on. Persisted logging lives beneath `/var/log/mcxTemplate/`
+and can be toggled by setting the `MCX_LOG_TO_FILE=1` flag or by supplying an
+explicit `MCX_LOG_FILE` name during startup. The helper automatically creates
+the directory and log file and falls back to console-only logging if writes to
+the file fail.
+
+Scripts should source the helper file and rely on the logging functions instead
+of raw `echo` statements.

--- a/common/lib/common.sh
+++ b/common/lib/common.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Common shell helpers shared by mcxTemplate scripts.
+
+# Default location where log files live when file logging is enabled.
+: "${MCX_LOG_DIR:=/var/log/mcxTemplate}"
+# Default log file name used when no explicit file is requested.
+: "${MCX_LOG_FILE_NAME:=mcxTemplate.log}"
+# Flag that toggles file logging through environment configuration.
+: "${MCX_LOG_TO_FILE:=0}"
+# Optional environment override that names the log file to use.
+: "${MCX_LOG_FILE:=}"
+
+# Internal variable holding the active log file path (if any).
+MCX_LOG_FILE_PATH=""
+
+# Produce a timestamp once per log entry to keep logs traceable.
+mcx__log_timestamp() {
+    date '+%Y-%m-%d %H:%M:%S'
+}
+
+# Emit to stdout/stderr based on the severity level for easy consumption.
+mcx__log_console() {
+    local level="$1"
+    local line="$2"
+
+    case "${level}" in
+        INFO)
+            printf '%s\n' "${line}"
+            ;;
+        WARN|ERROR)
+            printf '%s\n' "${line}" >&2
+            ;;
+        *)
+            printf '%s\n' "${line}"
+            ;;
+    esac
+}
+
+# Append to the active log file when file logging is enabled.
+mcx__log_append_file() {
+    local line="$1"
+
+    if [[ -z "${MCX_LOG_FILE_PATH}" ]]; then
+        return 0
+    fi
+
+    if printf '%s\n' "${line}" >> "${MCX_LOG_FILE_PATH}"; then
+        return 0
+    fi
+
+    # Drop back to console-only logging if the append fails at runtime.
+    printf 'mcx_log: failed writing to %s, disabling file logging\n' "${MCX_LOG_FILE_PATH}" >&2
+    MCX_LOG_FILE_PATH=""
+    return 1
+}
+
+# Ensure the log directory exists before touching the log file.
+mcx__ensure_log_dir() {
+    if ! mkdir -p "${MCX_LOG_DIR}"; then
+        printf 'mcx_log: unable to create log directory %s\n' "${MCX_LOG_DIR}" >&2
+        return 1
+    fi
+}
+
+# Select the log file to write to, always rooted in MCX_LOG_DIR.
+mcx_log_set_file() {
+    local requested_name="${1:-${MCX_LOG_FILE_NAME}}"
+    local safe_name
+
+    # Always collapse to a simple file name so logs stay in MCX_LOG_DIR.
+    safe_name="$(basename "${requested_name}")"
+    if [[ -z "${safe_name}" ]]; then
+        printf 'mcx_log: empty log file name rejected\n' >&2
+        return 1
+    fi
+
+    if ! mcx__ensure_log_dir; then
+        return 1
+    fi
+
+    MCX_LOG_FILE_PATH="${MCX_LOG_DIR}/${safe_name}"
+
+    # Touch the file so operators get early feedback about permission issues.
+    if ! touch "${MCX_LOG_FILE_PATH}"; then
+        printf 'mcx_log: unable to touch log file %s\n' "${MCX_LOG_FILE_PATH}" >&2
+        MCX_LOG_FILE_PATH=""
+        return 1
+    fi
+
+    return 0
+}
+
+# Format the log line and send it to both console and file sinks.
+mcx__log_emit() {
+    local level="$1"
+    shift
+    local message="$*"
+    local stamp
+    local line
+
+    stamp="$(mcx__log_timestamp)"
+    line="[${stamp}] [${level}] ${message}"
+
+    mcx__log_console "${level}" "${line}"
+    mcx__log_append_file "${line}"
+}
+
+# Public helper to log informational messages.
+mcx_log_info() {
+    mcx__log_emit "INFO" "$@"
+}
+
+# Public helper to log warning messages.
+mcx_log_warn() {
+    mcx__log_emit "WARN" "$@"
+}
+
+# Public helper to log error messages.
+mcx_log_error() {
+    mcx__log_emit "ERROR" "$@"
+}
+
+# Respect configuration knobs once this library is sourced.
+mcx__log_auto_configure() {
+    if [[ -n "${MCX_LOG_FILE}" ]]; then
+        mcx_log_set_file "${MCX_LOG_FILE}"
+    elif [[ "${MCX_LOG_TO_FILE}" == "1" ]]; then
+        mcx_log_set_file "${MCX_LOG_FILE_NAME}"
+    fi
+}
+
+mcx__log_auto_configure

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Apply mcxTemplate templates using the shared helper library.
+
+set -euo pipefail
+# Grab the directory holding this script for relative path handling.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve repository root so that shared assets can be loaded consistently.
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck disable=SC1091
+# Import logging helpers that wrap timestamped output and file routing.
+source "${ROOT_DIR}/common/lib/common.sh"
+
+# Directory where rendered templates would live in a real deployment.
+TEMPLATE_OUTPUT_DIR="${ROOT_DIR}/output"
+
+# Render a placeholder template directory to keep the workflow observable.
+render_templates() {
+    mcx_log_info "Validating output directory at ${TEMPLATE_OUTPUT_DIR}"
+
+    if [[ ! -d "${TEMPLATE_OUTPUT_DIR}" ]]; then
+        mcx_log_warn "Creating missing output directory ${TEMPLATE_OUTPUT_DIR}"
+        if ! mkdir -p "${TEMPLATE_OUTPUT_DIR}"; then
+            mcx_log_error "Failed to create output directory ${TEMPLATE_OUTPUT_DIR}"
+            return 1
+        fi
+    fi
+
+    mcx_log_info "Templates processed successfully"
+}
+
+# Entry point that orchestrates the high-level steps.
+main() {
+    mcx_log_info "Starting template apply run"
+    render_templates
+    mcx_log_info "Finished template apply run"
+}
+
+main "$@"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Prepare directories and sanity checks before applying templates.
+
+set -euo pipefail
+# Identify script location to keep relative paths deterministic.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Compute repository root from the script location for asset access.
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck disable=SC1091
+# Import shared logging helpers so messaging stays consistent.
+source "${ROOT_DIR}/common/lib/common.sh"
+
+# State directory where temporary work files would be staged.
+STATE_DIR="${ROOT_DIR}/state"
+
+# Ensure that the state directory exists and explain any actions taken.
+prepare_state_dir() {
+    if [[ -d "${STATE_DIR}" ]]; then
+        mcx_log_info "State directory already present at ${STATE_DIR}"
+    else
+        mcx_log_warn "State directory missing, creating ${STATE_DIR}"
+        if ! mkdir -p "${STATE_DIR}"; then
+            mcx_log_error "Failed to create state directory ${STATE_DIR}"
+            return 1
+        fi
+        mcx_log_info "State directory ready"
+    fi
+}
+
+# Basic environment probe to inform the operator about available commands.
+check_dependencies() {
+    if ! command -v envsubst >/dev/null 2>&1; then
+        mcx_log_warn "envsubst command not found; template expansion will be limited"
+    else
+        mcx_log_info "All dependencies satisfied"
+    fi
+}
+
+# Entry point calling the pre-flight checks in order.
+main() {
+    mcx_log_info "Starting bootstrap checks"
+    check_dependencies
+    prepare_state_dir
+    mcx_log_info "Bootstrap checks completed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- restructure the logging helper to always mirror output to the console while optionally appending to a file
- add automatic configuration, graceful fallback when file writes fail, and document the behavior in the README
- harden the apply script by logging and exiting when output directory creation is unsuccessful

## Testing
- bash scripts/bootstrap.sh
- bash scripts/apply.sh

------
https://chatgpt.com/codex/tasks/task_e_68ceb4f00e88832f88457b93ecb6e268