### PR TITLE
Simplify logging helper and align with latest layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # mcxTemplate
 Templating engine for distro installations
+
+## Logging helpers
+The shell helpers in `common/lib/common.sh` expose timestamped logging functions
+(`mcx_log_info`, `mcx_log_warn`, and `mcx_log_error`). Console output always
+remains enabled so operators continue to see status messages even when file
+logging is turned on. Persisted logging lives beneath `/var/log/mcxTemplate/`
+and can be toggled by setting the `MCX_LOG_TO_FILE=1` flag or by supplying an
+explicit `MCX_LOG_FILE` name during startup. The helper automatically creates
+the directory and log file and falls back to console-only logging if writes to
+the file fail.
+
+Scripts should source the helper file and rely on the logging functions instead
+of raw `echo` statements.

--- a/common/lib/common.sh
+++ b/common/lib/common.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Logging helpers for mcxTemplate shell scripts with consistent format.
+# Functions stay small and predictable to follow the KISS principle.
+
+# Directory that stores log files; callers can override before sourcing.
+: "${MCX_LOG_DIR:=/var/log/mcxTemplate}"
+# Default log file name used when automatic selection is requested.
+: "${MCX_LOG_FILE_NAME:=mcxTemplate.log}"
+# Flag enabling file logging when set to 1; console logging stays on.
+: "${MCX_LOG_TO_FILE:=0}"
+# Optional explicit log file name provided by the operator or script.
+: "${MCX_LOG_FILE:=}"
+
+# Holds the fully-qualified log file path once logging to file is active.
+MCX_LOG_FILE_PATH=""
+
+# Create a timestamp string for each log entry to aid troubleshooting.
+mcx_log__timestamp() {
+    date '+%Y-%m-%d %H:%M:%S'
+}
+
+# Send a line to either stdout or stderr based on severity.
+mcx_log__console() {
+    local level="$1"
+    shift
+    local message="$*"
+
+    case "${level}" in
+        ERROR|WARN)
+            printf '%s\n' "${message}" >&2
+            ;;
+        *)
+            printf '%s\n' "${message}"
+            ;;
+    esac
+}
+
+# Append the line to the active log file and disable file logging on failure.
+mcx_log__write_file() {
+    local line="$1"
+
+    if [[ -z "${MCX_LOG_FILE_PATH}" ]]; then
+        return 0
+    fi
+
+    if printf '%s\n' "${line}" >> "${MCX_LOG_FILE_PATH}"; then
+        return 0
+    fi
+
+    mcx_log__console "WARN" "mcx_log: failed to write ${MCX_LOG_FILE_PATH}; disabling file logging"
+    MCX_LOG_FILE_PATH=""
+    return 1
+}
+
+# Ensure the log directory exists and the file is writable before use.
+mcx_log__activate_file() {
+    local requested="${1:-${MCX_LOG_FILE_NAME}}"
+    local file_name
+
+    file_name="$(basename "${requested}")"
+    if [[ -z "${file_name}" ]]; then
+        mcx_log__console "ERROR" "mcx_log: empty log file name ignored"
+        return 1
+    fi
+
+    if ! mkdir -p "${MCX_LOG_DIR}"; then
+        mcx_log__console "ERROR" "mcx_log: cannot create log directory ${MCX_LOG_DIR}"
+        return 1
+    fi
+
+    local path="${MCX_LOG_DIR}/${file_name}"
+
+    if ! touch "${path}"; then
+        mcx_log__console "ERROR" "mcx_log: cannot open log file ${path}"
+        return 1
+    fi
+
+    MCX_LOG_FILE_PATH="${path}"
+    return 0
+}
+
+# Public API to set the log file; leaves console logging untouched.
+mcx_log_set_file() {
+    local requested="${1:-${MCX_LOG_FILE_NAME}}"
+
+    if mcx_log__activate_file "${requested}"; then
+        return 0
+    fi
+
+    MCX_LOG_FILE_PATH=""
+    return 1
+}
+
+# Format the line with timestamp and severity before dispatching sinks.
+mcx_log__emit() {
+    local level="$1"
+    shift
+    local text="$*"
+    local stamp
+    local line
+
+    stamp="$(mcx_log__timestamp)"
+    line="[${stamp}] [${level}] ${text}"
+
+    mcx_log__console "${level}" "${line}"
+    mcx_log__write_file "${line}"
+}
+
+# Public helper for informational messages that go primarily to stdout.
+mcx_log_info() {
+    mcx_log__emit "INFO" "$@"
+}
+
+# Public helper for warning messages that highlight recoverable issues.
+mcx_log_warn() {
+    mcx_log__emit "WARN" "$@"
+}
+
+# Public helper for errors that typically stop the flow and need attention.
+mcx_log_error() {
+    mcx_log__emit "ERROR" "$@"
+}
+
+# Configure file logging automatically when the library is sourced.
+mcx_log_configure() {
+    if [[ -n "${MCX_LOG_FILE}" ]]; then
+        mcx_log_set_file "${MCX_LOG_FILE}" || return 1
+    elif [[ "${MCX_LOG_TO_FILE}" == "1" ]]; then
+        mcx_log_set_file "${MCX_LOG_FILE_NAME}" || return 1
+    fi
+
+    return 0
+}
+
+# Invoke configuration right away so scripts get predictable behavior.
+mcx_log_configure

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Apply mcxTemplate templates using the shared helper library.
+
+set -euo pipefail
+# Grab the directory holding this script for relative path handling.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve repository root so that shared assets can be loaded consistently.
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck disable=SC1091
+# Import logging helpers that wrap timestamped output and file routing.
+source "${ROOT_DIR}/common/lib/common.sh"
+
+# Directory where rendered templates would live in a real deployment.
+TEMPLATE_OUTPUT_DIR="${ROOT_DIR}/output"
+
+# Render a placeholder template directory to keep the workflow observable.
+render_templates() {
+    mcx_log_info "Validating output directory at ${TEMPLATE_OUTPUT_DIR}"
+
+    if [[ ! -d "${TEMPLATE_OUTPUT_DIR}" ]]; then
+        mcx_log_warn "Creating missing output directory ${TEMPLATE_OUTPUT_DIR}"
+        if ! mkdir -p "${TEMPLATE_OUTPUT_DIR}"; then
+            mcx_log_error "Failed to create output directory ${TEMPLATE_OUTPUT_DIR}"
+            return 1
+        fi
+    fi
+
+    mcx_log_info "Templates processed successfully"
+}
+
+# Entry point that orchestrates the high-level steps.
+main() {
+    mcx_log_info "Starting template apply run"
+    render_templates
+    mcx_log_info "Finished template apply run"
+}
+
+main "$@"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Prepare directories and sanity checks before applying templates.
+
+set -euo pipefail
+# Identify script location to keep relative paths deterministic.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Compute repository root from the script location for asset access.
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck disable=SC1091
+# Import shared logging helpers so messaging stays consistent.
+source "${ROOT_DIR}/common/lib/common.sh"
+
+# State directory where temporary work files would be staged.
+STATE_DIR="${ROOT_DIR}/state"
+
+# Ensure that the state directory exists and explain any actions taken.
+prepare_state_dir() {
+    if [[ -d "${STATE_DIR}" ]]; then
+        mcx_log_info "State directory already present at ${STATE_DIR}"
+    else
+        mcx_log_warn "State directory missing, creating ${STATE_DIR}"
+        if ! mkdir -p "${STATE_DIR}"; then
+            mcx_log_error "Failed to create state directory ${STATE_DIR}"
+            return 1
+        fi
+        mcx_log_info "State directory ready"
+    fi
+}
+
+# Basic environment probe to inform the operator about available commands.
+check_dependencies() {
+    if ! command -v envsubst >/dev/null 2>&1; then
+        mcx_log_warn "envsubst command not found; template expansion will be limited"
+    else
+        mcx_log_info "All dependencies satisfied"
+    fi
+}
+
+# Entry point calling the pre-flight checks in order.
+main() {
+    mcx_log_info "Starting bootstrap checks"
+    check_dependencies
+    prepare_state_dir
+    mcx_log_info "Bootstrap checks completed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- rewrite the shared logging helper to keep the timestamped console/file logic simple and consistent with current expectations
- keep automatic configuration for environment-provided log files while adding clear inline documentation for each helper

## Testing
- bash scripts/bootstrap.sh
- bash scripts/apply.sh

------
https://chatgpt.com/codex/tasks/task_e_68ceb4f00e88832f88457b93ecb6e268