### PR TITLE
Rework hostname tooling under distros/common

### DIFF
--- a/distros/common/bin/README.md
+++ b/distros/common/bin/README.md
@@ -1,0 +1,28 @@
+# Hostname Configuration Script
+
+The `configure_hostname.php` script configures both the static and pretty hostnames
+for a machine. The script is designed to be idempotent and uses system tools such as
+`hostnamectl` when available, with a fallback to the legacy `hostname` utility.
+
+## Usage
+
+Run the script with PHP while ensuring the required environment variable is set:
+
+```bash
+MCX_HOSTNAME="example-host" MCX_PRETTY_HOSTNAME="Example Host" php configure_hostname.php
+```
+
+* `MCX_HOSTNAME` (required) — the static hostname that will be applied.
+* `MCX_PRETTY_HOSTNAME` (optional) — the descriptive hostname applied when
+  `hostnamectl` supports it.
+
+The script must be executed with root privileges because it modifies system
+hostname settings and may update `/etc/hostname`.
+
+## Behavior
+
+1. Validates required environment variables and hostname formatting.
+2. Detects the best available hostname tool (`hostnamectl` preferred).
+3. Applies the static hostname and, when possible, the pretty hostname.
+4. Leaves the system unchanged if the hostname already matches the requested
+   value, aside from ensuring the pretty hostname when provided.

--- a/distros/common/bin/configure_hostname.php
+++ b/distros/common/bin/configure_hostname.php
@@ -1,0 +1,101 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+use Distros\Common\Common;
+
+require __DIR__ . '/../lib/Common.php';
+
+// Configure the system hostname using templated environment variables.
+Common::ensureRoot();
+$desiredHostname = Common::requireEnv('MCX_HOSTNAME');
+$prettyHostname = trim((string) (getenv('MCX_PRETTY_HOSTNAME') ?: ''));
+
+// Validate the provided hostname so that bad values do not reach the OS.
+if (!Common::isValidHostname($desiredHostname)) {
+    Common::fail("'{$desiredHostname}' is not a valid hostname.");
+}
+
+// Keep the flow easy to read by splitting retrieval into a helper.
+$currentHostname = getCurrentHostname();
+if ($currentHostname === $desiredHostname) {
+    Common::logInfo("Hostname already set to '{$desiredHostname}'.");
+    if ($prettyHostname !== '') {
+        Common::logInfo('Ensuring pretty hostname is applied for completeness.');
+        applyHostname($desiredHostname, $prettyHostname);
+    }
+    exit(0);
+}
+
+// Apply the desired hostname while reporting what changed.
+Common::logInfo("Updating hostname from '" . ($currentHostname !== '' ? $currentHostname : 'unknown') . "' to '{$desiredHostname}'.");
+applyHostname($desiredHostname, $prettyHostname);
+Common::logInfo('Hostname successfully updated.');
+
+// Read the current hostname using the best available tool.
+function getCurrentHostname(): string
+{
+    if (Common::commandExists('hostnamectl')) {
+        $status = 0;
+        $staticName = Common::runCommand(['hostnamectl', '--static'], $status);
+        if ($status === 0 && $staticName !== '') {
+            return $staticName;
+        }
+    }
+
+    // Fallback to the traditional hostname command when necessary.
+    $status = 0;
+    $legacyName = Common::runCommand(['hostname'], $status);
+    if ($status === 0) {
+        return $legacyName;
+    }
+
+    // Return an empty string so the caller can handle unknown cases.
+    return '';
+}
+
+// Apply static and pretty hostnames with graceful fallbacks.
+function applyHostname(string $staticName, string $prettyName): void
+{
+    if (Common::commandExists('hostnamectl')) {
+        $status = 0;
+        Common::runCommand(['hostnamectl', 'set-hostname', $staticName], $status);
+        if ($status !== 0) {
+            Common::fail('Failed to set static hostname via hostnamectl.');
+        }
+
+        // Apply the pretty hostname when one is provided.
+        if ($prettyName !== '') {
+            Common::runCommand(['hostnamectl', 'set-hostname', $prettyName, '--pretty'], $status);
+            if ($status !== 0) {
+                Common::fail('Failed to set pretty hostname via hostnamectl.');
+            }
+        }
+        return;
+    }
+
+    // Legacy systems only have the hostname command available.
+    if (!Common::commandExists('hostname')) {
+        Common::fail("Required command 'hostname' not found in PATH.");
+    }
+
+    $status = 0;
+    Common::runCommand(['hostname', $staticName], $status);
+    if ($status !== 0) {
+        Common::fail('Failed to set hostname via the legacy hostname command.');
+    }
+
+    // Update /etc/hostname when we have write access so reboots persist.
+    if (is_writable('/etc/hostname') || (!file_exists('/etc/hostname') && is_writable('/etc'))) {
+        if (@file_put_contents('/etc/hostname', $staticName . PHP_EOL) === false) {
+            Common::logInfo('Unable to update /etc/hostname; continuing.');
+        }
+    } else {
+        Common::logInfo('/etc/hostname not writable; skipping file update.');
+    }
+
+    // Pretty hostnames are unsupported without hostnamectl but we inform the user.
+    if ($prettyName !== '') {
+        Common::logInfo('Pretty hostname requested but hostnamectl is unavailable.');
+    }
+}

--- a/distros/common/lib/Common.php
+++ b/distros/common/lib/Common.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Distros\Common;
+
+// Shared utility helpers for distro provisioning scripts.
+final class Common
+{
+    // Keep logging consistent across every script for easy parsing.
+    public static function logInfo(string $message): void
+    {
+        fwrite(STDOUT, '[INFO] ' . $message . PHP_EOL);
+    }
+
+    // Emit clear error messages that stand out from normal output.
+    public static function logError(string $message): void
+    {
+        fwrite(STDERR, '[ERROR] ' . $message . PHP_EOL);
+    }
+
+    // Stop execution when we encounter an unrecoverable problem.
+    public static function fail(string $message): void
+    {
+        self::logError($message);
+        exit(1);
+    }
+
+    // Guard that required environment variables are present and non-empty.
+    public static function requireEnv(string $name): string
+    {
+        $value = getenv($name);
+        if ($value === false || trim($value) === '') {
+            self::fail("Environment variable '{$name}' must be set.");
+        }
+        return trim((string) $value);
+    }
+
+    // Confirm that the script is executing with root privileges.
+    public static function ensureRoot(): void
+    {
+        if (function_exists('posix_geteuid')) {
+            if (posix_geteuid() !== 0) {
+                self::fail('This action requires root privileges.');
+            }
+        } elseif (getenv('USER') !== 'root') {
+            self::fail('Root privileges are required.');
+        }
+    }
+
+    // Provide a simple command existence check using the system shell.
+    public static function commandExists(string $command): bool
+    {
+        $result = shell_exec('command -v ' . escapeshellarg($command) . ' 2>/dev/null');
+        return is_string($result) && trim($result) !== '';
+    }
+
+    // Reuse a single wrapper for command execution across scripts.
+    public static function runCommand(array $command, ?int &$status = null): string
+    {
+        $escaped = array_map('escapeshellarg', $command);
+        $commandLine = implode(' ', $escaped) . ' 2>/dev/null';
+        $outputLines = [];
+        exec($commandLine, $outputLines, $exitCode);
+        $status = $exitCode;
+        return trim(implode("\n", $outputLines));
+    }
+
+    // Validate hostnames against a conservative RFC 1123 inspired pattern.
+    public static function isValidHostname(string $candidate): bool
+    {
+        if ($candidate === '') {
+            return false;
+        }
+        return (bool) preg_match('/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/', $candidate);
+    }
+}


### PR DESCRIPTION
## Summary
- move the hostname utilities into the new `distros/common` hierarchy
- replace the Bash helper library with a reusable PHP `Common` utility class
- implement `configure_hostname.php` to manage hostnames idempotently and document its usage

## Testing
- php -l distros/common/lib/Common.php
- php -l distros/common/bin/configure_hostname.php

------
https://chatgpt.com/codex/tasks/task_e_68ceb5346a3c832fa9f4ef934303ced3