### PR TITLE
Refine Debian post-install to share PHP fstab helper

### DIFF
--- a/distros/README.md
+++ b/distros/README.md
@@ -1,0 +1,24 @@
+# Distribution Hooks
+
+The `distros/` tree stores provisioning hooks that run inside the
+`mcxTemplate` chroot. Each distro keeps its lifecycle scripts alongside any
+supporting notes so the behaviour stays predictable across releases.
+
+## Layout Overview
+
+- `distros/common/` keeps cross-distro assets such as the PHP fstab writer.
+- `lib/common/` holds shared shell helpers such as logging and root checks.
+- `<distro>/common/` contains the default hook implementations for a distro.
+- `<distro>/<version>/` overrides any hook that changed for a specific release
+  while keeping documentation that is unique to that version.
+
+This layered layout keeps common logic in one place and only forks code when a
+release genuinely needs different behaviour. New distros should follow the same
+pattern: place reusable code in `common/` and let versioned directories provide
+small wrappers or overrides.
+
+## Naming Convention
+
+Version directories use the numeric major version (for example `12`) to reduce
+renames between testing and release builds. READMEs should mention the matching
+codename (such as “bookworm”) so both references stay clear to operators.

--- a/distros/common/write_fstab.php
+++ b/distros/common/write_fstab.php
@@ -1,0 +1,48 @@
+#!/usr/bin/env php
+<?php
+// -----------------------------------------------------------------------------
+// write_fstab.php - Common /etc/fstab writer for mcxTemplate provisioning.
+// Called from distro post-install tasks once partitions are ready to mount.
+// -----------------------------------------------------------------------------
+
+declare(strict_types=1);
+// The script uses strict types so accidental nulls trigger visible failures.
+
+$defaults = [
+    'ROOT_DEVICE' => '/dev/nvme0n1p2',
+    'HOME_DEVICE' => '/dev/nvme0n1p3',
+    'BOOT_DEVICE' => '/dev/md1',
+    'SWAP_DEVICE' => '/dev/nvme0n1p1',
+];
+// Defaults mirror the historical clone workflow and can be overridden via env.
+
+$getValue = static function (string $key) use ($defaults): string {
+    $raw = getenv($key);
+    if ($raw === false) {
+        return $defaults[$key];
+    }
+    $trimmed = trim($raw);
+    return $trimmed === '' ? $defaults[$key] : $trimmed;
+};
+// Fetch configuration values while falling back to predictable defaults.
+
+$lines = [
+    '# /etc/fstab: static file system information.',
+    '#',
+    "# Use 'blkid' to print the universally unique identifier for a device.",
+    '# <file system> <mount point>   <type>  <options>       <dump>  <pass>',
+    sprintf('%s /               ext4    errors=remount-ro 0       1', $getValue('ROOT_DEVICE')),
+    sprintf('%s /home           ext4    defaults        0       2', $getValue('HOME_DEVICE')),
+    sprintf('%s /boot           ext4    defaults        0       2', $getValue('BOOT_DEVICE')),
+    sprintf('%s none            swap    sw              0       0', $getValue('SWAP_DEVICE')),
+];
+// Compose the canonical fstab entries in the same order as the legacy scripts.
+
+$payload = implode(PHP_EOL, $lines) . PHP_EOL;
+// Ensure the rendered file always ends with a trailing newline for POSIX tools.
+
+if (file_put_contents('/etc/fstab', $payload) === false) {
+    fwrite(STDERR, "ERROR: Unable to write /etc/fstab\n");
+    exit(1);
+}
+// Abort loudly when the file cannot be written so the operator notices quickly.

--- a/distros/debian/12/README.md
+++ b/distros/debian/12/README.md
@@ -1,0 +1,18 @@
+# Debian 12 (Bookworm) Notes
+
+Debian 12 currently reuses the shared Debian hooks found in
+`../common/pre_install.sh` and `../common/post_install.sh`. The wrapper scripts in
+this directory simply `exec` those implementations so the behaviour stays in
+sync with other Debian releases.
+
+## Release Checklist
+
+- Confirm the NVMe + md raid boot layout matches the production Bookworm images before
+  cutting a release build.
+- Regenerate SSH host keys and machine-id during validation to ensure the
+  pre-install hook still clears all unique identifiers.
+- Verify `update-initramfs`, `update-grub`, and `grub-install` remain available
+  in the chroot; adjust `GRUB_TARGETS` when Bookworm images change boot devices.
+
+If Bookworm diverges from newer releases, copy the necessary lines into this
+folder and keep the shared hooks untouched for the rest of the Debian family.

--- a/distros/debian/12/post_install.sh
+++ b/distros/debian/12/post_install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Debian 12 post-install hook wrapper.
+# Delegates to the shared Debian implementation in distros/debian/common/.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+# Maintain consistent behaviour and immediate failure semantics.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve directory once to keep path logic simple.
+
+exec "${SCRIPT_DIR}/../common/post_install.sh" "$@"
+# Run the shared implementation, allowing future overrides when needed.

--- a/distros/debian/12/pre_install.sh
+++ b/distros/debian/12/pre_install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Debian 12 pre-install hook wrapper.
+# Delegates to the shared Debian implementation in distros/debian/common/.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+# Maintain consistent behaviour and immediate failure semantics.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve directory once to keep path logic simple.
+
+exec "${SCRIPT_DIR}/../common/pre_install.sh" "$@"
+# Run the shared implementation, allowing future overrides when needed.

--- a/distros/debian/README.md
+++ b/distros/debian/README.md
@@ -1,0 +1,41 @@
+# Debian Hook Overview
+
+The Debian hooks standardise the final provisioning steps after a filesystem is
+cloned into place. The logic mirrors the historical `cloneLiveSystem.sh`
+workflow so Bookworm and future releases boot with the expected layout.
+
+## Shared Implementation
+
+- `common/pre_install.sh` resets SSH host keys, clears the machine-id, and wipes
+  stale resume configuration before packages are touched.
+- `common/post_install.sh` rebuilds `/etc/fstab`, hostname data, static
+  networking, and bootloader configuration using the known NVMe-first layout.
+  The fstab content itself comes from `../../common/write_fstab.php` so other
+  distros can reuse the same PHP helper.
+- Shared helpers live in `../../lib/common/` and provide logging plus root
+  validation routines.
+
+Each version directory can replace either script when Debian changes defaults,
+but should otherwise delegate back to the common implementation to avoid drift.
+
+## Environment Overrides
+
+The post-install hook accepts simple overrides so lab systems can tweak the
+layout without editing the script:
+
+| Variable | Purpose |
+| --- | --- |
+| `HOSTNAME_DOMAIN` | Domain appended to the detected hostname. |
+| `ROOT_DEVICE` | Device path mounted as `/`. |
+| `HOME_DEVICE` | Device path mounted as `/home`. |
+| `BOOT_DEVICE` | Device path mounted as `/boot`. |
+| `SWAP_DEVICE` | Device path registered as swap. |
+| `GRUB_TARGETS` | Space-separated device list passed to `grub-install`. |
+
+Keep overrides minimal so the shared defaults remain a reliable baseline.
+
+## Version Directories
+
+Directories such as `12/` (Debian Bookworm) wrap the shared scripts. When
+Bookworm and a later release diverge, copy only the lines that changed into the
+new versioned hook and leave the rest in `common/`.

--- a/distros/debian/common/post_install.sh
+++ b/distros/debian/common/post_install.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Debian post-install hook for mcxTemplate.
+# Applies configuration matching the historical cloneLiveSystem process.
+# Shared by all Debian releases unless a version provides an override.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+# Abort on any failure to maintain predictable provisioning runs.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Cache script location for relative lookups.
+
+COMMON_LIB_DIR="${SCRIPT_DIR}/../../../lib/common"
+# Shared helper library directory used by distro lifecycle scripts.
+DISTRO_COMMON_DIR="${SCRIPT_DIR}/../../common"
+# Shared distro assets such as PHP helpers for rendering config files.
+
+# shellcheck source=../../../lib/common/logging.sh
+source "${COMMON_LIB_DIR}/logging.sh"
+# shellcheck source=../../../lib/common/system.sh
+source "${COMMON_LIB_DIR}/system.sh"
+
+# Allow overriding default devices and domain through environment variables.
+: "${HOSTNAME_DOMAIN:=pulsedmedia.com}"
+: "${SWAP_DEVICE:=/dev/nvme0n1p1}"
+: "${ROOT_DEVICE:=/dev/nvme0n1p2}"
+: "${HOME_DEVICE:=/dev/nvme0n1p3}"
+: "${BOOT_DEVICE:=/dev/md1}"
+: "${GRUB_TARGETS:=/dev/sda /dev/sdb}"
+
+# derive_hostname extracts the short hostname from the kernel command line.
+derive_hostname() {
+  local kernel_arg
+  kernel_arg="$(sed -n 's/.*hostname=\([^ ]*\).*/\1/p' /proc/cmdline | head -n1)"
+  if [[ -z "${kernel_arg}" ]]; then
+    kernel_arg="$(hostname | cut -d'.' -f1)"
+    log_warn "hostname= kernel parameter missing, falling back to ${kernel_arg}."
+  fi
+  printf '%s' "${kernel_arg%%.*}"
+}
+
+# gather_network_information records IPv4 CIDR and gateway for later templates.
+gather_network_information() {
+  NETWORK_CIDR="$(ip -o -f inet addr show scope global | awk '{print $4; exit}')"
+  if [[ -z "${NETWORK_CIDR}" ]]; then
+    log_warn "No global IPv4 address detected; network templates will use defaults."
+  fi
+  IP_ADDRESS="${NETWORK_CIDR%%/*}"
+  GATEWAY="$(ip route | awk '/default/ {print $3; exit}')"
+  if [[ -z "${GATEWAY}" ]]; then
+    log_warn "Gateway not found in routing table; leaving interfaces without gateway."
+  fi
+}
+
+# write_fstab reproduces the static layout expected by the clone workflow.
+write_fstab() {
+  local writer="${DISTRO_COMMON_DIR}/write_fstab.php"
+  if [[ ! -x "${writer}" ]]; then
+    log_error "Common fstab writer missing at ${writer}."
+    exit 1
+  fi
+  log_info "Writing /etc/fstab with Debian device mappings via PHP helper."
+  ROOT_DEVICE="${ROOT_DEVICE}" \
+  HOME_DEVICE="${HOME_DEVICE}" \
+  BOOT_DEVICE="${BOOT_DEVICE}" \
+  SWAP_DEVICE="${SWAP_DEVICE}" \
+  "${writer}"
+}
+
+# configure_mdadm writes array metadata when mdadm is installed in the chroot.
+configure_mdadm() {
+  if command_exists mdadm; then
+    log_info "Capturing mdadm array metadata into /etc/mdadm/mdadm.conf."
+    mdadm --detail --scan > /etc/mdadm/mdadm.conf
+  else
+    log_warn "mdadm not installed; skipping mdadm.conf generation."
+  fi
+}
+
+# write_hostname_files updates /etc/hostname and /etc/hosts entries.
+write_hostname_files() {
+  local short_hostname="$1"
+  local fqdn="${short_hostname}.${HOSTNAME_DOMAIN}"
+  log_info "Setting hostname to ${fqdn}."
+  printf '%s\n' "${fqdn}" > /etc/hostname
+  local host_ip="${IP_ADDRESS:-127.0.1.1}"
+  cat <<EOF_HOSTS > /etc/hosts
+127.0.0.1       localhost
+${host_ip}    ${short_hostname} ${fqdn}
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+EOF_HOSTS
+}
+
+# write_interfaces builds a simple static /etc/network/interfaces template.
+write_interfaces() {
+  local cidr_value="${NETWORK_CIDR:-192.0.2.10/24}"
+  log_info "Writing /etc/network/interfaces with primary address ${cidr_value}."
+  cat <<EOF_INTERFACES > /etc/network/interfaces
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+source /etc/network/interfaces.d/*
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+auto eth0
+iface eth0 inet static
+    address ${cidr_value}
+EOF_INTERFACES
+  if [[ -n "${GATEWAY:-}" ]]; then
+    printf '    gateway %s\n' "${GATEWAY}" >> /etc/network/interfaces
+  fi
+}
+
+# update_boot_components refreshes initramfs, grub.cfg, and bootloaders.
+update_boot_components() {
+  log_info "Updating initramfs and GRUB configuration."
+  run_if_command_exists update-initramfs -u || true
+  run_if_command_exists update-grub || true
+  local device
+  for device in ${GRUB_TARGETS}; do
+    if [[ -b "${device}" ]]; then
+      log_info "Installing GRUB to ${device}."
+      run_if_command_exists grub-install "${device}" || true
+    else
+      log_warn "Block device ${device} missing; skipping GRUB installation."
+    fi
+  done
+}
+
+main() {
+  require_root
+  log_info "Debian post-install hook started."
+  local short_hostname
+  short_hostname="$(derive_hostname)"
+  gather_network_information
+  write_hostname_files "${short_hostname}"
+  write_interfaces
+  write_fstab
+  configure_mdadm
+  update_boot_components
+  log_info "Debian post-install hook completed successfully."
+}
+
+main "$@"

--- a/distros/debian/common/pre_install.sh
+++ b/distros/debian/common/pre_install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Debian pre-install hook for mcxTemplate.
+# Runs inside the chroot prior to final configuration steps.
+# Shared by all Debian releases unless a version provides an override.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+# Fail fast so provisioning halts on the first unexpected issue.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve the current directory once for repeat use.
+
+COMMON_LIB_DIR="${SCRIPT_DIR}/../../../lib/common"
+# Shared helper library location used by distro hooks.
+
+# shellcheck source=../../../lib/common/logging.sh
+source "${COMMON_LIB_DIR}/logging.sh"
+# shellcheck source=../../../lib/common/system.sh
+source "${COMMON_LIB_DIR}/system.sh"
+
+# clear_ssh_host_keys removes any copied host keys before regenerating them.
+clear_ssh_host_keys() {
+  log_info "Removing stale SSH host keys copied from the source image."
+  rm -f /etc/ssh/ssh_host_* || true
+  log_info "Regenerating SSH host keys for the cloned system."
+  run_if_command_exists ssh-keygen -A || true
+}
+
+# reset_machine_identifier ensures the new system has a unique machine-id.
+reset_machine_identifier() {
+  log_info "Resetting machine-id to avoid duplicate identifiers."
+  rm -f /etc/machine-id || true
+  if ! run_if_command_exists systemd-machine-id-setup; then
+    log_warn "systemd-machine-id-setup missing, creating empty machine-id."
+    : > /etc/machine-id
+  fi
+}
+
+# clean_resume_configuration drops stale resume settings referencing old swap.
+clean_resume_configuration() {
+  local resume_file="/etc/initramfs-tools/conf.d/resume"
+  if [[ -f "${resume_file}" ]]; then
+    log_info "Sanitising ${resume_file} to remove stale RESUME entries."
+    sed -i '/^RESUME=/d' "${resume_file}"
+    if [[ ! -s "${resume_file}" ]]; then
+      log_info "Removing empty resume configuration file."
+      rm -f "${resume_file}"
+    fi
+  else
+    log_info "Resume configuration not found; nothing to clean."
+  fi
+}
+
+main() {
+  require_root
+  log_info "Debian pre-install hook started."
+  clear_ssh_host_keys
+  reset_machine_identifier
+  clean_resume_configuration
+  log_info "Debian pre-install hook completed successfully."
+}
+
+main "$@"

--- a/lib/common/logging.sh
+++ b/lib/common/logging.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# logging.sh - Shared logging helpers for mcxTemplate provisioning scripts.
+# Provides small wrappers so every script prints in a consistent format.
+# -----------------------------------------------------------------------------
+
+# Prevent duplicate definitions when sourced multiple times.
+if [[ -n "${MCX_LOGGING_SH:-}" ]]; then
+  return 0
+fi
+MCX_LOGGING_SH=1
+
+# format_time outputs an ISO-8601 timestamp for log lines.
+format_time() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+# log_with_level prints a message prefixed with a timestamp and severity tag.
+log_with_level() {
+  local level="$1"
+  shift
+  printf '%s [%s] %s\n' "$(format_time)" "${level}" "$*"
+}
+
+# Informational logging for normal progress updates.
+log_info() {
+  log_with_level INFO "$@"
+}
+
+# Warning logging for recoverable issues that need attention.
+log_warn() {
+  log_with_level WARN "$@"
+}
+
+# Error logging for unrecoverable problems before exiting.
+log_error() {
+  log_with_level ERROR "$@"
+}

--- a/lib/common/system.sh
+++ b/lib/common/system.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# system.sh - Shared system helpers reused by provisioning scripts.
+# Keeps small utility helpers in one place to reduce duplication.
+# -----------------------------------------------------------------------------
+
+# Avoid redefining helpers when sourced repeatedly by nested scripts.
+if [[ -n "${MCX_SYSTEM_SH:-}" ]]; then
+  return 0
+fi
+MCX_SYSTEM_SH=1
+
+# command_exists checks whether the given executable is present in PATH.
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# require_root stops execution unless the current user is root.
+require_root() {
+  if [[ "${EUID}" -ne 0 ]]; then
+    if command_exists log_error; then
+      log_error "Root privileges are required for provisioning steps."
+    else
+      echo "ERROR: Root privileges are required for provisioning steps." >&2
+    fi
+    exit 1
+  fi
+}
+
+# run_if_command_exists executes a command when available and logs otherwise.
+run_if_command_exists() {
+  local executable="$1"
+  shift
+  if command_exists "${executable}"; then
+    "${executable}" "$@"
+    return 0
+  fi
+  if command_exists log_warn; then
+    log_warn "Skipped ${executable} because it is not installed."
+  else
+    echo "WARN: Skipped ${executable} because it is not installed." >&2
+  fi
+  return 1
+}


### PR DESCRIPTION
## Summary
- add a shared distros/common/write_fstab.php helper so any distro can render /etc/fstab via PHP
- switch the Debian post-install hook to call the PHP helper and drop the unused USB mount logic
- refresh the Debian documentation to describe the shared helper and updated environment knobs

## Testing
- bash -n distros/debian/common/post_install.sh
- bash -n distros/debian/common/pre_install.sh
- bash -n distros/debian/12/pre_install.sh
- bash -n distros/debian/12/post_install.sh
- php -l distros/common/write_fstab.php


------
https://chatgpt.com/codex/tasks/task_e_68ceb5265c3c832f9bf234cf473d4112