### PR TITLE
Clarify AGENTS project context and language guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,19 @@
 # Repository Guidelines
 
+## Project Context
+- **Purpose**: mcxTemplate operates as a templating engine for distro installations; align automation choices with provisioning workflows suitable for that environment.
+- **Shared Library First**: Prefer sourcing helpers from `common/lib/common.sh` or other existing utilities before creating new logic.
+
 ## Core Principles
 - **KISS Principle**: Keep implementations simple, readable, and direct. Avoid unnecessary abstractions or over-engineering.
 - **Single-Method Consistency**: When a problem has already been solved in this codebase, reuse the established method instead of introducing alternate approaches. Prefer shared helpers/abstractions over duplicating logic.
 - **MVC Layering Mindset**: Organize logic so that data access, business rules, and presentation/output responsibilities remain clearly separated. Apply this separation consistently from method structure to overall file organization.
+- **Fail-Soft Bias**: Favor recovering and continuing whenever safe instead of terminating execution. Only halt when the outcome would be catastrophic or data-damaging, and document the reason when an exit becomes unavoidable.
+- **Readability & Reuse**: Prioritize human readability, comment generously, and reuse existing helpers rather than duplicating logic in new forms.
 - **Predictable Provisioning Flow**: Scripts should follow a deliberate sequence—detect environment, gather inputs, prepare resources, execute actions, and report status—mirroring the clone-and-configure workflow in the reference tooling. Make every transition between steps explicit.
 - **Change Justification**: Only make modifications when there is a clear, documented reason. Do not alter stable, long-lived behavior without evidence that change is required.
 - **Commenting Rule**: Maintain comments such that, on average, at least one line of commentary appears for every ten lines of code (Linux Kernel style guidance).
-- **Language Policy**: Limit new executable scripting to Bash or PHP unless explicitly instructed otherwise.
+- **Language Policy**: Default to Bash for automation tasks. Step up to PHP when workflows become lengthy or complex, keeping the logic centralized. Do **not** introduce Python; if a requirement appears to demand it, escalate instead of adding a Python dependency.
 
 ## Operational Philosophy
 - **Safety First**: Destructive actions (partitioning, formatting, wiping identifiers) must be guarded with clear intent checks, informative logging, and opportunities for dry runs or confirmation steps where practical.


### PR DESCRIPTION
## Summary
- note the mcxTemplate provisioning context and highlight reusing shared helpers like common/lib/common.sh
- reinforce fail-soft expectations by requiring explanations when exits are unavoidable
- clarify the language policy to default to Bash, escalate to PHP for complex flows, and avoid Python entirely

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cec7f0bc90832f94c52d2a5f1c58a1