### PR TITLE
Replace packaging helper with PHP workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,2 @@
 # mcxTemplate
-
-Templating engine for distro installations.
-
-## Repository Layout
-
-* `common/` – Shared templating engine logic used by distro-specific templates.
-* `tools/` – Standalone utilities that help capture live systems and package
-  assets for new templates. See [`tools/README.md`](tools/README.md) for
-  details.
-
-## Tools Overview
-
-The first tool provided is `packageLiveSystem.php`, a PHP helper that connects
-to a remote host, copies its file system, includes the templating engine,
-bundles optional local assets (ISO, QCOW2, etc.), and produces a pigz-compressed
-archive ready for template creation. Full documentation and usage examples live
-in the [`tools/README.md`](tools/README.md) file.
+Templating engine for distro installations

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # mcxTemplate
-Templating engine for distro installations
+
+Templating engine for distro installations.
+
+## Repository Layout
+
+* `common/` – Shared templating engine logic used by distro-specific templates.
+* `tools/` – Standalone utilities that help capture live systems and package
+  assets for new templates. See [`tools/README.md`](tools/README.md) for
+  details.
+
+## Tools Overview
+
+The first tool provided is `packageLiveSystem.php`, a PHP helper that connects
+to a remote host, copies its file system, includes the templating engine,
+bundles optional local assets (ISO, QCOW2, etc.), and produces a pigz-compressed
+archive ready for template creation. Full documentation and usage examples live
+in the [`tools/README.md`](tools/README.md) file.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,68 @@
+# mcxTemplate Tools
+
+The `tools/` directory collects helper scripts that operate outside of a
+specific distro template. These utilities automate the workflow required to
+capture a running system and prepare an archive that already bundles the mcx
+templating engine alongside any additional artefacts you may need when
+crafting new templates.
+
+## packageLiveSystem.php
+
+`packageLiveSystem.php` connects to a live Linux system over SSH, copies the
+root file system into a temporary staging area, adds the repository templating
+engine, optionally includes extra local files (ISO images, QCOW2 disks, custom
+scripts, etc.), and finally produces a `pigz`-compressed tarball. The PHP
+implementation keeps the workflow layered:
+
+1. **Source acquisition** – fetches the distro via rsync/SSH.
+2. **Copy preparation** – assembles the rsync statement with consistent
+   exclusions for runtime mounts.
+3. **Packaging** – builds a pigz-compressed archive ready for template reuse.
+
+### Dependencies
+
+* `php`
+* `ssh`
+* `rsync`
+* `tar`
+* `pigz`
+
+All dependencies are available in standard Debian and Ubuntu repositories. The
+remote host must allow SSH access for the provided user and that user must have
+permission to read the entire file system tree.
+
+### Usage
+
+```bash
+php tools/packageLiveSystem.php --source-host mcx-node-01.example.com \
+    --source-user root \
+    --output /srv/templates/mcx-node-01.tar.gz \
+    --extra /var/lib/vz/template/iso/debian-12.iso \
+    --extra /var/lib/vz/images/900/vm-900-disk-0.qcow2
+```
+
+The example command captures the remote host `mcx-node-01.example.com` as root,
+saves the archive to `/srv/templates/mcx-node-01.tar.gz`, and embeds two local
+artefacts under the `extras/` directory inside the archive. If `--output` is
+omitted the tool writes to `./template-<host>-<timestamp>.tar.gz`.
+
+### Archive Contents
+
+The resulting tarball contains three top-level directories:
+
+* `rootfs/` – A faithful copy of the remote file system (excluding runtime
+  mounts such as `/proc` or `/sys`).
+* `template/` – A copy of the repository `common/` templating engine.
+* `extras/` – Optional files supplied through `--extra`. The directory is
+  omitted when no additional assets are provided.
+
+### Notes
+
+* The script honours the KISS principle: each stage has a dedicated PHP
+  function and the orchestration mirrors the A/B/C layering described above.
+* Compression is handled via `pigz` to speed up packaging on multi-core
+  systems.
+* Temporary data is stored in a PHP-created directory under the system temp
+  path and automatically removed on exit.
+* For large systems ensure the local machine has sufficient disk space to store
+  the uncompressed staging directory during packaging.

--- a/tools/packageLiveSystem.php
+++ b/tools/packageLiveSystem.php
@@ -1,0 +1,284 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+// packageLiveSystem.php captures a live system into a staging directory.
+// The script is intentionally modular to keep the sourcing, copying, and
+// packaging responsibilities clear and easy to audit for future additions.
+
+ini_set('display_errors', 'stderr');
+
+// Constant exclude list keeps runtime mounts out of the archived rootfs.
+const RUNTIME_EXCLUDES = [
+    '/dev/*',
+    '/proc/*',
+    '/sys/*',
+    '/tmp/*',
+    '/run/*',
+    '/mnt/*',
+    '/media/*',
+    '/lost+found',
+];
+
+// printUsage renders a short help message for operators running the tool.
+function printUsage(): void
+{
+    $script = basename(__FILE__);
+    echo "Usage: {$script} --source-host <host> [options]\n";
+    echo "\n";
+    echo "Options:\n";
+    echo "  --source-host <host>   Hostname or IP for the SSH source.\n";
+    echo "  --source-user <user>   SSH user. Defaults to root.\n";
+    echo "  --output <file>        Target tar.gz file path.\n";
+    echo "  --template <path>      Local templating engine directory.\n";
+    echo "  --extra <path>         Extra local file or directory to embed.\n";
+    echo "  --help                 Show this message and exit.\n";
+}
+
+// fail prints an error message and exits with status code one.
+function fail(string $message): void
+{
+    fwrite(STDERR, $message . "\n");
+    exit(1);
+}
+
+// ensureBinary confirms an executable is reachable in PATH.
+function ensureBinary(string $binary): void
+{
+    $result = trim((string) shell_exec('command -v ' . escapeshellarg($binary)));
+    if ($result === '') {
+        fail("Required command '{$binary}' not found in PATH.");
+    }
+}
+
+// parseArguments converts CLI switches into a predictable config array.
+function parseArguments(array $argv): array
+{
+    $config = [
+        'sourceMode' => 'ssh',
+        'sourceHost' => '',
+        'sourceUser' => 'root',
+        'outputPath' => '',
+        'templatePath' => realpath(__DIR__ . '/../common') ?: '',
+        'extras' => [],
+    ];
+
+    // Walk arguments sequentially to keep parsing simple and transparent.
+    for ($i = 1; $i < count($argv); $i++) {
+        $arg = $argv[$i];
+        switch ($arg) {
+            case '--source-host':
+                $config['sourceHost'] = $argv[++$i] ?? '';
+                break;
+            case '--source-user':
+                $config['sourceUser'] = $argv[++$i] ?? 'root';
+                break;
+            case '--output':
+                $config['outputPath'] = $argv[++$i] ?? '';
+                break;
+            case '--template':
+                // Always resolve template path to an absolute directory.
+                $config['templatePath'] = realpath($argv[++$i] ?? '') ?: '';
+                break;
+            case '--extra':
+                $extraInput = $argv[++$i] ?? '';
+                $extra = realpath($extraInput);
+                if ($extra !== false) {
+                    $config['extras'][] = $extra;
+                } else {
+                    fwrite(STDERR, "Skipping missing extra path: {$extraInput}\n");
+                }
+                break;
+            case '--help':
+                printUsage();
+                exit(0);
+            default:
+                fail("Unknown argument '{$arg}'.");
+        }
+    }
+
+    if ($config['templatePath'] === '') {
+        fail('Template path not found.');
+    }
+
+    return $config;
+}
+
+// createStagingDirectory prepares a temporary workspace under /tmp.
+function createStagingDirectory(): string
+{
+    $path = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'mcxTemplate-' . uniqid();
+    if (!mkdir($path, 0755, true)) {
+        fail('Unable to create staging directory.');
+    }
+    registerCleanup($path);
+    return $path;
+}
+
+// registerCleanup ensures the staging directory is removed on exit.
+function registerCleanup(string $path): void
+{
+    register_shutdown_function(static function () use ($path): void {
+        removeDirectory($path);
+    });
+}
+
+// removeDirectory recursively deletes the staging directory contents.
+function removeDirectory(string $path): void
+{
+    if (!is_dir($path)) {
+        return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($iterator as $item) {
+        if ($item->isDir()) {
+            rmdir($item->getPathname());
+        } else {
+            unlink($item->getPathname());
+        }
+    }
+
+    rmdir($path);
+}
+
+// finalizeConfig enforces inputs and supplies defaults before work begins.
+function finalizeConfig(array $config): array
+{
+    if ($config['sourceHost'] === '') {
+        fail('Missing required --source-host value.');
+    }
+
+    if ($config['outputPath'] === '') {
+        // Use a timestamped filename when the caller does not choose one.
+        $timestamp = date('Ymd-His');
+        $config['outputPath'] = getcwd() . DIRECTORY_SEPARATOR . 'template-' . $config['sourceHost'] . '-' . $timestamp . '.tar.gz';
+    }
+
+    $outputDirectory = dirname($config['outputPath']);
+    if (!is_dir($outputDirectory) && !mkdir($outputDirectory, 0755, true)) {
+        fail('Unable to create output directory.');
+    }
+
+    // Validate toolchain binaries that the workflow depends on.
+    ensureBinary('rsync');
+    ensureBinary('tar');
+    ensureBinary('pigz');
+
+    if ($config['sourceMode'] === 'ssh') {
+        ensureBinary('ssh');
+    }
+
+    return $config;
+}
+
+// fetchSource handles stage A by retrieving the rootfs from the source.
+function fetchSource(array $config, string $stagingDir): void
+{
+    $target = $stagingDir . DIRECTORY_SEPARATOR . 'rootfs';
+    if (!mkdir($target, 0755) && !is_dir($target)) {
+        fail('Unable to create rootfs staging directory.');
+    }
+
+    // Stage A is fulfilled by rsync copying the remote root into rootfs/.
+    $command = buildRsyncCommand($config, $target);
+    runCommand($command);
+}
+
+// buildRsyncCommand assembles the rsync statement with exclusions.
+function buildRsyncCommand(array $config, string $target): string
+{
+    $parts = ['rsync', '-aAXH', '--numeric-ids'];
+
+    foreach (RUNTIME_EXCLUDES as $pattern) {
+        $parts[] = '--exclude=' . escapeshellarg($pattern);
+    }
+
+    // Remote root is transferred via SSH using rsync's remote shell syntax.
+    $remote = sprintf('%s@%s:/', $config['sourceUser'], $config['sourceHost']);
+    $parts[] = escapeshellarg($remote);
+    // Trailing slash keeps rsync copying into the prepared rootfs folder.
+    $parts[] = escapeshellarg($target . DIRECTORY_SEPARATOR);
+
+    return implode(' ', $parts);
+}
+
+// runCommand executes an external command and stops on failure.
+function runCommand(string $command): void
+{
+    passthru($command, $status);
+    if ($status !== 0) {
+        fail("Command failed: {$command}");
+    }
+}
+
+// copyTemplatingEngine mirrors the templating engine into staging.
+function copyTemplatingEngine(array $config, string $stagingDir): void
+{
+    $destination = $stagingDir . DIRECTORY_SEPARATOR . 'template';
+    if (!mkdir($destination, 0755) && !is_dir($destination)) {
+        fail('Unable to create template staging directory.');
+    }
+
+    copyLocalPath($config['templatePath'], $destination);
+}
+
+// copyLocalPath reuses rsync for consistent attribute handling.
+function copyLocalPath(string $source, string $destination): void
+{
+    $cleanSource = rtrim($source, DIRECTORY_SEPARATOR);
+    // rsync preserves permissions and symlinks which template archives expect.
+    $command = sprintf('rsync -a %s %s', escapeshellarg($cleanSource), escapeshellarg($destination));
+    runCommand($command);
+}
+
+// copyExtras brings optional files under the extras directory.
+function copyExtras(array $config, string $stagingDir): void
+{
+    if (count($config['extras']) === 0) {
+        return;
+    }
+
+    $destination = $stagingDir . DIRECTORY_SEPARATOR . 'extras';
+    if (!mkdir($destination, 0755) && !is_dir($destination)) {
+        fail('Unable to create extras staging directory.');
+    }
+
+    // Copy each validated extra path into the extras staging area.
+    foreach ($config['extras'] as $extra) {
+        copyLocalPath($extra, $destination);
+    }
+}
+
+// createArchive runs stage C by building the pigz compressed tarball.
+function createArchive(array $config, string $stagingDir): void
+{
+    $output = $config['outputPath'];
+    // Stage C compresses the staging directory into the requested archive.
+    $command = sprintf(
+        'tar --numeric-owner --xattrs --acls -I pigz -cf %s -C %s .',
+        escapeshellarg($output),
+        escapeshellarg($stagingDir)
+    );
+
+    runCommand($command);
+    echo "Archive created at {$output}\n";
+}
+
+// main orchestrates the sourcing, preparation, and packaging layers.
+function main(array $argv): void
+{
+    $config = parseArguments($argv);
+    $config = finalizeConfig($config);
+    $stagingDir = createStagingDirectory();
+    fetchSource($config, $stagingDir);
+    copyTemplatingEngine($config, $stagingDir);
+    copyExtras($config, $stagingDir);
+    createArchive($config, $stagingDir);
+}
+
+main($argv);


### PR DESCRIPTION
## Summary
- replace the Bash-based live system packager with a PHP implementation that separates sourcing, copy preparation, and pigz packaging
- document the new PHP tooling, dependencies, and layered workflow in `tools/README.md`
- update the main README to reference `packageLiveSystem.php`

## Testing
- php -l tools/packageLiveSystem.php

------
https://chatgpt.com/codex/tasks/task_e_68cec5867260832fa19681b17de3b12a