### PR TITLE
Refactor Debian post-install templating into PHP helpers

### DIFF
--- a/distros/common/write_hostname_files.php
+++ b/distros/common/write_hostname_files.php
@@ -1,0 +1,69 @@
+#!/usr/bin/env php
+<?php
+// -----------------------------------------------------------------------------
+// write_hostname_files.php - Maintain hostname and hosts files for templates.
+// Converts the Bash templating logic into PHP for easier maintenance.
+// -----------------------------------------------------------------------------
+
+declare(strict_types=1);
+// Stick with strict types to catch parameter mistakes early.
+
+use Distros\Common\Common;
+// Import shared helpers so logging and failures match the other scripts.
+
+require __DIR__ . '/lib/Common.php';
+// Load the helper definitions exactly once from the shared library.
+
+Common::ensureRoot();
+// Refuse to continue when the caller lacks the necessary privileges.
+
+$shortHostname = trim((string) (getenv('SHORT_HOSTNAME') ?: ''));
+// Capture the short hostname that callers detected from /proc/cmdline.
+if ($shortHostname === '') {
+    Common::fail("Environment variable 'SHORT_HOSTNAME' must be provided.");
+    // Fail early because the rest of the script depends on this value.
+}
+
+$fqdn = trim((string) (getenv('FQDN') ?: ''));
+// Pull the fully-qualified name so /etc/hostname mirrors the legacy flow.
+if ($fqdn === '') {
+    Common::fail("Environment variable 'FQDN' must be provided.");
+    // Keep the behaviour strict to avoid writing broken hostnames.
+}
+
+$hostIp = trim((string) (getenv('HOST_IP') ?: ''));
+// Allow overriding the IPv4 address while keeping historical defaults.
+if ($hostIp === '') {
+    $hostIp = '127.0.1.1';
+    // Fallback matches the previous Bash implementation when IP was empty.
+}
+
+if (@file_put_contents('/etc/hostname', $fqdn . PHP_EOL) === false) {
+    Common::fail('Unable to write /etc/hostname.');
+    // Stop immediately when we cannot update the hostname file on disk.
+}
+
+Common::logInfo('Updated /etc/hostname with ' . $fqdn . '.');
+// Emit a short note so operators know the hostname changed.
+
+$hostsLines = [
+    '127.0.0.1       localhost',
+    $hostIp . '    ' . $shortHostname . ' ' . $fqdn,
+    '',
+    '# The following lines are desirable for IPv6 capable hosts',
+    '::1     localhost ip6-localhost ip6-loopback',
+    'ff02::1 ip6-allnodes',
+    'ff02::2 ip6-allrouters',
+];
+// Mirror the canonical /etc/hosts layout maintained for Debian images.
+
+$hostsContent = implode(PHP_EOL, $hostsLines) . PHP_EOL;
+// Build the final file content, preserving the trailing newline for POSIX.
+
+if (@file_put_contents('/etc/hosts', $hostsContent) === false) {
+    Common::fail('Unable to write /etc/hosts.');
+    // Halt provisioning so the system does not boot with a broken hosts file.
+}
+
+Common::logInfo('Updated /etc/hosts with IPv4 and IPv6 defaults.');
+// Record success to match the verbosity of the original Bash helper.

--- a/distros/common/write_interfaces.php
+++ b/distros/common/write_interfaces.php
@@ -1,0 +1,61 @@
+#!/usr/bin/env php
+<?php
+// -----------------------------------------------------------------------------
+// write_interfaces.php - Render /etc/network/interfaces for mcxTemplate.
+// Moves the templating out of Bash so we keep the complex bits in PHP.
+// -----------------------------------------------------------------------------
+
+declare(strict_types=1);
+// Strict types help spot subtle bugs before we touch system files.
+
+use Distros\Common\Common;
+// Reuse the shared helper utilities for consistency across scripts.
+
+require __DIR__ . '/lib/Common.php';
+// Include the library once so we share behaviour with other helpers.
+
+Common::ensureRoot();
+// Guard privileged operations early to fail fast on misuse.
+
+$cidr = trim((string) (getenv('NETWORK_CIDR') ?: ''));
+// Fetch the provided CIDR value from the environment.
+if ($cidr === '') {
+    $cidr = '192.0.2.10/24';
+    // Maintain the legacy default when nothing is supplied.
+}
+
+$gateway = trim((string) (getenv('GATEWAY') ?: ''));
+// Accept an optional gateway while keeping empty strings clean.
+
+$lines = [
+    '# This file describes the network interfaces available on your system',
+    '# and how to activate them. For more information, see interfaces(5).',
+    '',
+    'source /etc/network/interfaces.d/*',
+    '',
+    '# The loopback network interface',
+    'auto lo',
+    'iface lo inet loopback',
+    '',
+    '# The primary network interface',
+    'auto eth0',
+    'iface eth0 inet static',
+    '    address ' . $cidr,
+];
+// Compose the canonical Debian interface configuration for eth0.
+
+if ($gateway !== '') {
+    $lines[] = '    gateway ' . $gateway;
+    // Append the gateway line only when we actually detected one.
+}
+
+$content = implode(PHP_EOL, $lines) . PHP_EOL;
+// Join everything together and keep the trailing newline intact.
+
+if (@file_put_contents('/etc/network/interfaces', $content) === false) {
+    Common::fail('Unable to write /etc/network/interfaces.');
+    // Abort loudly so provisioning stops on partial network configs.
+}
+
+Common::logInfo('Updated /etc/network/interfaces via PHP helper.');
+// Provide a friendly confirmation for the provisioning logs.


### PR DESCRIPTION
## Summary
- move the Debian hostname and network file writers out of Bash and into dedicated PHP helpers
- update the post-install hook to call the new helpers so templating stays consistent with existing PHP tooling

## Testing
- php -l distros/common/write_interfaces.php
- php -l distros/common/write_hostname_files.php
- bash -n distros/debian/common/post_install.sh

------
https://chatgpt.com/codex/tasks/task_e_68ceccee82dc832f8de3cc1e17dce0a2