### PR TITLE
Add Debian 11 and 13 hook wrappers

### DIFF
--- a/distros/debian/11/README.md
+++ b/distros/debian/11/README.md
@@ -1,0 +1,19 @@
+# Debian 11 (Bullseye) Notes
+
+Debian 11 consumes the shared Debian hooks stored in
+`../common/pre_install.sh` and `../common/post_install.sh`. These wrapper
+scripts simply delegate to the common implementation so every release stays
+aligned unless Bullseye requires specific overrides in the future.
+
+## Release Checklist
+
+- Confirm the Bullseye images still ship with the NVMe plus md raid boot layout
+  prior to creating a release artifact.
+- Verify the pre-install hook clears SSH host keys and the machine-id during
+  validation.
+- Ensure `update-initramfs`, `update-grub`, and `grub-install` remain available
+  in the chroot environment. Update `GRUB_TARGETS` only when Bullseye images
+  change their boot device expectations.
+
+When Bullseye diverges from newer releases, copy only the changed lines into
+this directory and keep the shared hooks untouched for the rest of Debian.

--- a/distros/debian/11/post_install.sh
+++ b/distros/debian/11/post_install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Debian 11 post-install hook wrapper.
+# Keeps Bullseye aligned with the shared Debian implementation.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+# Maintain consistent behaviour and immediate failure semantics.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve directory once to keep path logic simple.
+
+exec "${SCRIPT_DIR}/../common/post_install.sh" "$@"
+# Run the shared implementation, allowing future overrides when needed.

--- a/distros/debian/11/pre_install.sh
+++ b/distros/debian/11/pre_install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Debian 11 pre-install hook wrapper.
+# Keeps Bullseye aligned with the shared Debian implementation.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+# Maintain consistent behaviour and immediate failure semantics.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve directory once to keep path logic simple.
+
+exec "${SCRIPT_DIR}/../common/pre_install.sh" "$@"
+# Run the shared implementation, allowing future overrides when needed.

--- a/distros/debian/13/README.md
+++ b/distros/debian/13/README.md
@@ -1,0 +1,18 @@
+# Debian 13 (Trixie) Notes
+
+Debian 13 tracks the shared Debian hooks in
+`../common/pre_install.sh` and `../common/post_install.sh`. The wrapper scripts
+in this directory delegate to the common implementation so Trixie behaviour
+matches Bullseye and Bookworm unless this release requires dedicated overrides.
+
+## Release Checklist
+
+- Validate the NVMe-first plus md raid boot layout remains consistent with the
+  shipping Trixie images before tagging a release.
+- Confirm the pre-install hook still removes SSH host keys and regenerates the
+  machine-id during validation.
+- Ensure `update-initramfs`, `update-grub`, and `grub-install` continue to exist
+  in the chroot; only adjust `GRUB_TARGETS` if Trixie images switch boot devices.
+
+If Trixie deviates from earlier releases, copy only the required changes into
+this directory while leaving the shared Debian hooks untouched.

--- a/distros/debian/13/post_install.sh
+++ b/distros/debian/13/post_install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Debian 13 post-install hook wrapper.
+# Keeps Trixie aligned with the shared Debian implementation.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+# Maintain consistent behaviour and immediate failure semantics.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve directory once to keep path logic simple.
+
+exec "${SCRIPT_DIR}/../common/post_install.sh" "$@"
+# Run the shared implementation, allowing future overrides when needed.

--- a/distros/debian/13/pre_install.sh
+++ b/distros/debian/13/pre_install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Debian 13 pre-install hook wrapper.
+# Keeps Trixie aligned with the shared Debian implementation.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+# Maintain consistent behaviour and immediate failure semantics.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve directory once to keep path logic simple.
+
+exec "${SCRIPT_DIR}/../common/pre_install.sh" "$@"
+# Run the shared implementation, allowing future overrides when needed.

--- a/distros/debian/README.md
+++ b/distros/debian/README.md
@@ -36,6 +36,7 @@ Keep overrides minimal so the shared defaults remain a reliable baseline.
 
 ## Version Directories
 
-Directories such as `12/` (Debian Bookworm) wrap the shared scripts. When
-Bookworm and a later release diverge, copy only the lines that changed into the
-new versioned hook and leave the rest in `common/`.
+Directories such as `11/` (Debian Bullseye), `12/` (Debian Bookworm), and
+`13/` (Debian Trixie) wrap the shared scripts. When a release diverges, copy
+only the lines that changed into the new versioned hook and leave the rest in
+`common/`.


### PR DESCRIPTION
## Summary
- add Debian 11 and 13 wrapper hooks that delegate to the shared Debian implementation
- document Bullseye, Bookworm, and Trixie directories in the Debian hook overview

## Testing
- shfmt -w distros/debian/11/pre_install.sh distros/debian/11/post_install.sh distros/debian/13/pre_install.sh distros/debian/13/post_install.sh
- shellcheck distros/debian/11/pre_install.sh distros/debian/11/post_install.sh distros/debian/13/pre_install.sh distros/debian/13/post_install.sh
- bash -n distros/debian/11/pre_install.sh distros/debian/11/post_install.sh distros/debian/13/pre_install.sh distros/debian/13/post_install.sh

------
https://chatgpt.com/codex/tasks/task_e_68cecc085908832fbb9212cf7c1600cf