### PR TITLE
Ensure user.d overrides remain ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Site-specific override hooks executed by configure.sh
-/distros/**/user.d/
+/distros/**/user.d/*
+# Retain placeholder rules for hook directories while ignoring site overrides
+!/distros/**/user.d/.gitignore

--- a/distros/debian/common/user.d/.gitignore
+++ b/distros/debian/common/user.d/.gitignore
@@ -1,0 +1,3 @@
+# Keep the user hook directory tracked while ignoring local overrides
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- scope the distros user.d ignore rule to file contents and re-include placeholder files
- add a tracked .gitignore inside the Debian common user.d directory to document the hook location

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cede44b990832fbe7010679974bffa