### PR TITLE
Document distro installer flow

### DIFF
--- a/distros/README.md
+++ b/distros/README.md
@@ -4,23 +4,53 @@ The `distros/` tree stores provisioning hooks that run inside the mcxTemplate
 chroot. Each distro keeps its task scripts alongside documentation so behaviour
 stays predictable across releases.
 
-## Layout Overview
+## Template Installer Overview
 
-- `configure.php` detects the active distro/version and executes tasks in order.
-- `<distro>/common/tasks/` holds the default task list for the distro.
-- `<distro>/<version>/tasks/` contains overrides when a release diverges.
-- `user.d/` directories at each level allow site-specific PHP hooks that are
-  ignored by Git but executed after the built-in tasks.
-- `../common/` keeps reusable helpers (for example the PHP hostname writers).
+The provisioning entry point is `configure.php`. The script reads the current
+system's `/etc/os-release`, determines the distro and major version, and then
+executes the matching task directories. Tasks are standard PHP files so every
+step can share the helper routines in `distros/common/lib/Common.php` without
+bringing in extra interpreters or rewriting control flow.
 
-Tasks are named with a numeric prefix (`10-`, `20-`, …) so alphabetical sorting
-matches the desired execution order. Tasks are implemented in PHP so they can
-reuse the shared helper library shipped in `distros/common/lib` without
-introducing additional interpreters.
+Execution order mirrors the historical Bash runner:
+
+1. Load shared helpers and guard that the operator is running as root.
+2. Detect the distro ID/version (or accept overrides from `MCX_DISTRO_ID` and
+   `MCX_DISTRO_VERSION`).
+3. Run `common/tasks/` for the distro, followed by any files in
+   `common/user.d/` so local sites can layer custom behaviour.
+4. When a version directory exists (for example `debian/bookworm/`), run its
+   `tasks/` and `user.d/` directories in the same order.
+5. Warn instead of aborting when optional helpers are missing so the installer
+   stays resilient during partially prepared images.
+
+Each task script executes through the system PHP binary via `proc_open()`.
+This keeps logging consistent, avoids shell quoting edge cases, and mirrors how
+operators would run the helpers manually for troubleshooting.
+
+## Key Files and Rationale
+
+- `configure.php` – Single entry point that glues detection, logging, and task
+  orchestration together. Centralising the logic avoids subtle differences
+  between distros and keeps the execution sequence predictable.
+- `common/lib/Common.php` – Shared logging, privilege guards, command runners,
+  and helper utilities. Using one library keeps behaviour consistent while
+  letting tasks stay focused on their immediate job.
+- `<distro>/common/tasks/` – Default task set for the distro. Files use numeric
+  prefixes (`10-`, `20-`, …) so alphabetical sorting provides a deterministic
+  pipeline that mirrors the provisioning checklist.
+- `<distro>/<version>/tasks/` – Optional overrides when a release needs
+  different behaviour. The directory structure mirrors the common tasks so
+  maintainers only fork when necessary.
+- `user.d/` directories – Git-ignored hooks that downstream operators can use to
+  append site-specific actions. They run after the built-in tasks, providing a
+  stable escape hatch without patching upstream code.
+- `../common/*.php` – Shared helpers (for example hostname and network writers)
+  that supply repeatable building blocks across distros.
 
 ## Adding a New Distro
 
-1. Create `distros/<distro>/common/tasks/` and populate ordered scripts.
+1. Create `distros/<distro>/common/tasks/` and populate ordered PHP scripts.
 2. Add optional `distros/<distro>/<version>/tasks/` when a release diverges from
    the shared defaults.
 3. Drop any local overrides into `user.d/` while keeping them out of version

--- a/distros/debian/README.md
+++ b/distros/debian/README.md
@@ -1,20 +1,22 @@
 # Debian Tasks
 
-Debian provisioning runs through the ordered task scripts stored in
+Debian provisioning runs through the ordered PHP task scripts stored in
 `common/tasks/`. Each script handles a specific responsibility so the flow stays
-simple and easy to audit.
+simple and easy to audit. Tasks all include `distros/common/lib/Common.php` so
+logging, privilege checks, and helper routines remain consistent with other
+distros.
 
 ## Task Breakdown
 
-1. `10-reset-system-identifiers.sh` – Removes SSH host keys, resets
+1. `10-reset-system-identifiers.php` – Removes SSH host keys, resets
    `/etc/machine-id`, and cleans stale resume configuration copied from the
-   template image.
-2. `20-configure-identity.sh` – Derives the hostname, updates `/etc/hostname`
+   template image so every clone boots with unique identifiers.
+2. `20-configure-identity.php` – Derives the hostname, updates `/etc/hostname`
    and `/etc/hosts`, and renders `/etc/network/interfaces` using the shared PHP
-   helpers.
-3. `30-configure-storage.sh` – Regenerates `/etc/fstab` and records mdadm array
+   helpers in `distros/common/`.
+3. `30-configure-storage.php` – Regenerates `/etc/fstab` and records mdadm array
    metadata when mdadm is available inside the chroot.
-4. `40-update-boot.sh` – Refreshes initramfs images, rebuilds `grub.cfg`, and
+4. `40-update-boot.php` – Refreshes initramfs images, rebuilds `grub.cfg`, and
    reinstalls GRUB onto the configured boot devices.
 
 Tasks execute alphabetically, so adding a new step simply requires choosing an
@@ -29,7 +31,7 @@ For now Debian uses only the shared `common` tasks.
 
 ## User Overrides
 
-Place site-specific shell or PHP scripts inside `common/user.d/` (or the
+Place site-specific PHP scripts inside `common/user.d/` (or the
 version-specific equivalent). Files in these directories are ignored by Git but
 will run after the built-in tasks, allowing last-minute tweaks without forking
 upstream code.


### PR DESCRIPTION
## Summary
- explain how distros/configure.php now drives template installation and why PHP tasks were chosen
- describe the shared helper layout and rationale for common/task directories
- fix Debian task documentation to reference the PHP task scripts and their responsibilities

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cedc5a67b4832f99cfc1a857e8dd8f