### PR TITLE
Add System integration tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="mcxTemplate">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Lib/Common/SystemTest.php
+++ b/tests/Lib/Common/SystemTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Lib\Common;
+
+use Lib\Common\System;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+// SystemTest validates the minimal command helpers without depending on system-specific state.
+final class SystemTest extends TestCase
+{
+    // commandExists should confirm standard shells exist and bogus commands do not.
+    public function testCommandExistsDetectsCommands(): void
+    {
+        $this->assertTrue(System::commandExists('sh'));
+        $this->assertFalse(System::commandExists('definitely-not-real'));
+    }
+
+    // run streams passthru output, so we focus on exit codes to stay environment-agnostic.
+    public function testRunHandlesExitCodesWithoutTerminating(): void
+    {
+        $successStatus = System::run(['true'], false);
+        $this->assertSame(0, $successStatus);
+
+        $failureStatus = System::run(['false'], true);
+        $this->assertNotSame(0, $failureStatus);
+    }
+
+    // capture should return stdout and report the exit code via the reference parameter.
+    public function testCaptureReturnsOutputAndStatus(): void
+    {
+        $output = System::capture([PHP_BINARY, '-r', 'echo "ping";'], $status);
+        $this->assertSame('ping', $output);
+        $this->assertSame(0, $status);
+    }
+
+    // buildCommand must reject empty command vectors so callers supply at least one token.
+    public function testRunWithEmptyCommandThrowsException(): void
+    {
+        $this->expectException(RuntimeException::class);
+        System::run([]);
+    }
+
+    // runIfCommandExists should silently skip commands that are not present while logging the warning.
+    public function testRunIfCommandExistsSkipsUnknownCommand(): void
+    {
+        $result = System::runIfCommandExists('definitely-not-real');
+        $this->assertFalse($result);
+    }
+
+    // runIfCommandExists should return false when the wrapped command exits with a non-zero status.
+    public function testRunIfCommandExistsPropagatesExitCodes(): void
+    {
+        $result = System::runIfCommandExists('sh', ['-c', 'exit 7']);
+        $this->assertFalse($result);
+    }
+
+    // runIfCommandExists should return true when the executable exists and exits cleanly.
+    public function testRunIfCommandExistsRunsCommandSuccessfully(): void
+    {
+        $result = System::runIfCommandExists('sh', ['-c', 'exit 0']);
+        $this->assertTrue($result);
+    }
+
+    // runWithEnv uses passthru, so we assert on the exit status to remain insensitive to stdout.
+    public function testRunWithEnvInjectsEnvironmentVariables(): void
+    {
+        $status = System::runWithEnv('sh', ['PING' => 'PONG'], ['-c', 'test "$PING" = "PONG"']);
+        $this->assertSame(0, $status);
+    }
+
+    // isBlockDevice should reject files and paths that do not point to block device nodes.
+    public function testIsBlockDeviceIdentifiesRegularFilesAsFalse(): void
+    {
+        $this->assertFalse(System::isBlockDevice(__FILE__));
+        $this->assertFalse(System::isBlockDevice('/definitely/not/here'));
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,23 @@
+# Test Suite
+
+This repository keeps the PHPUnit configuration lightweight so the shared `Lib\\Common` helpers load through the small autoloader in `tests/bootstrap.php`.
+
+## Prerequisites
+
+* PHP 8.1 or newer with the `pcntl` and `posix` extensions enabled.
+* [PHPUnit 9](https://phpunit.de/) installed either via Composer (`composer require --dev phpunit/phpunit`) or by downloading the PHAR (`wget https://phar.phpunit.de/phpunit-9.phar`).
+
+## Running the Tests
+
+1. Ensure PHPUnit is on your `$PATH` or available as `./vendor/bin/phpunit` when using Composer.
+2. Execute the suite from the project root:
+   ```bash
+   ./vendor/bin/phpunit --configuration phpunit.xml.dist
+   ```
+   *When using the PHAR directly, replace the command above with `php phpunit-9.phar --configuration phpunit.xml.dist`.*
+3. The tests intentionally assert on exit codes rather than stdout/stderr content because `System::run()` forwards output using `passthru`. This keeps the expectations stable across environments with different shell noise levels.
+
+## Troubleshooting
+
+* If PHPUnit cannot locate classes, confirm the repository is cloned with its relative directory layout intact so `tests/bootstrap.php` can map the `Lib\\Common` namespace.
+* When commands like `sh` are missing, install your distribution's POSIX shell package or update the tests to target an equivalent binary available on your platform.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+// Register an autoloader so PHPUnit can resolve shared library classes.
+spl_autoload_register(static function (string $class): void {
+    // We only serve classes from the Lib\Common namespace here.
+    $prefix = 'Lib\\Common\\';
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+
+    // Build the file path relative to the repository structure.
+    $relativeClass = substr($class, strlen($prefix));
+    $path = __DIR__ . '/../lib/common/' . str_replace('\\', '/', $relativeClass) . '.php';
+
+    // Include the file when it exists to keep the autoloader quiet otherwise.
+    if (is_file($path)) {
+        require_once $path;
+    }
+});


### PR DESCRIPTION
## Summary
- add a lightweight PHPUnit configuration and bootstrap that autoloads Lib\Common classes
- cover Lib\Common\System command helpers with integration tests, including runIfCommandExists, runWithEnv, and isBlockDevice checks
- document how to execute the PHPUnit suite in tests/README.md

## Testing
- php -l tests/bootstrap.php
- php -l tests/Lib/Common/SystemTest.php
- ./vendor/bin/phpunit --configuration phpunit.xml.dist *(fails: file not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cedefcbe60832f9e28c296d37f8c60