### PR TITLE
Harden template capture tooling

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -6,10 +6,106 @@ capture a running system and prepare an archive that already bundles the mcx
 templating engine alongside any additional artefacts you may need when
 crafting new templates.
 
-## packageLiveSystem.php
+## Quick Reference
 
-`packageLiveSystem.php` connects to a live Linux system over SSH, copies the
-root file system into a temporary staging area, adds the repository templating
+* `templateCloneRemote.php` – Capture a live system over SSH and write the
+  archive locally or to STDOUT.
+* `templateCloneImage.php` – Mount a disk image read-only, copy its root file
+  system, and compress the result on the local machine.
+* `templateAssemble.php` – Stage a remote system into a local workspace,
+  bundle the templating engine, and package the combination as a template.
+* `lib/packageCommon.php` – Internal helper library shared by the tooling. You
+  rarely invoke it directly, but all scripts depend on its checks and
+  path-handling helpers.
+
+## Getting Started
+
+1. Ensure the host running these scripts has `php` available. Root privileges
+   are required for operations that attach loop devices or mount images.
+2. Review the synopsis for the tool you plan to use and confirm the required
+   dependencies (remote SSH access, local `rsync`, etc.).
+3. Run `php tools/<script>.php --help` to view inline usage details at any
+   time. Each script prints a concise summary of its arguments and options.
+4. Execute the command examples below, adjusting hosts, paths, and options to
+   match your environment.
+
+The sections that follow list dependencies, usage examples, and workflow notes
+for each script.
+
+## templateCloneRemote.php
+
+`templateCloneRemote.php` mirrors the `cloneLiveSystem.sh` reference flow by
+streaming a remote root file system over SSH. The PHP implementation asks the
+remote host to create a tarball, compresses it with `pigz` when available
+(falling back to `gzip`), and writes the archive locally without staging a full
+copy.
+
+### Dependencies
+
+* `php`
+* `ssh`
+* `tar`
+* `pigz` or `gzip` on the remote host
+
+### Synopsis
+
+```bash
+php tools/templateCloneRemote.php <user@host> <output|-> [--ssh-option <option>]... [--force]
+```
+
+### Usage
+
+```bash
+php tools/templateCloneRemote.php root@mcx-node-01.example.com /srv/templates/mcx-node-01.tar.gz
+```
+
+* Pass `-` (or `stdout`) as the second argument to stream the archive to
+  standard output for further piping.
+* Forward additional SSH parameters through repeated `--ssh-option` flags. The
+  value accepts multi-token strings, so both `--ssh-option "-p 2222"` and
+  `--ssh-option "-o StrictHostKeyChecking=no"` are handled safely.
+* Add `--force` to overwrite an existing archive file on the local system.
+
+## templateCloneImage.php
+
+`templateCloneImage.php` targets offline images. It detects whether the image is
+raw or QCOW2, attaches it read-only via `losetup` or `qemu-nbd`, waits for
+partitions to appear, auto-selects a mountable partition (including filesystem
+images without a partition table), and then compresses the mounted root file
+system locally with `pigz` (falling back to `gzip`).
+
+### Dependencies
+
+* `php`
+* `tar`
+* `pigz`
+* `qemu-img`
+* `losetup`
+* `lsblk`
+* `mount`
+* `qemu-nbd` (only when handling QCOW2 images)
+
+The tool must run with root privileges to attach loop devices and mount the
+image. Provide `--partition <num>` when automatic detection cannot identify the
+desired partition.
+
+### Synopsis
+
+```bash
+sudo php tools/templateCloneImage.php --image <path> --output <path> [--partition <num>]
+```
+
+### Usage
+
+```bash
+sudo php tools/templateCloneImage.php --image /srv/images/base.img \
+    --output /srv/templates/base.tar.gz
+```
+
+## templateAssemble.php
+
+`templateAssemble.php` connects to a live Linux system over SSH, copies the root
+file system into a temporary staging area, adds the repository templating
 engine, optionally includes extra local files (ISO images, QCOW2 disks, custom
 scripts, etc.), and finally produces a `pigz`-compressed tarball. The PHP
 implementation keeps the workflow layered:
@@ -31,20 +127,28 @@ All dependencies are available in standard Debian and Ubuntu repositories. The
 remote host must allow SSH access for the provided user and that user must have
 permission to read the entire file system tree.
 
+### Synopsis
+
+```bash
+php tools/templateAssemble.php --source-host <host> --source-user <user> [options]
+```
+
 ### Usage
 
 ```bash
-php tools/packageLiveSystem.php --source-host mcx-node-01.example.com \
+php tools/templateAssemble.php --source-host mcx-node-01.example.com \
     --source-user root \
     --output /srv/templates/mcx-node-01.tar.gz \
     --extra /var/lib/vz/template/iso/debian-12.iso \
-    --extra /var/lib/vz/images/900/vm-900-disk-0.qcow2
+    --extra /var/lib/vz/images/900/vm-900-disk-0.qcow2 \
+    --ssh-option "-p 2222"
 ```
 
 The example command captures the remote host `mcx-node-01.example.com` as root,
 saves the archive to `/srv/templates/mcx-node-01.tar.gz`, and embeds two local
 artefacts under the `extras/` directory inside the archive. If `--output` is
-omitted the tool writes to `./template-<host>-<timestamp>.tar.gz`.
+omitted the tool writes to a timestamped `template-<host>-<timestamp>.tar.gz`
+file with the host name sanitised to filesystem-friendly characters.
 
 ### Archive Contents
 
@@ -62,6 +166,7 @@ The resulting tarball contains three top-level directories:
   function and the orchestration mirrors the A/B/C layering described above.
 * Compression is handled via `pigz` to speed up packaging on multi-core
   systems.
+* Additional SSH parameters can be forwarded to `rsync` through `--ssh-option`.
 * Temporary data is stored in a PHP-created directory under the system temp
   path and automatically removed on exit.
 * For large systems ensure the local machine has sufficient disk space to store

--- a/tools/lib/packageCommon.php
+++ b/tools/lib/packageCommon.php
@@ -1,0 +1,152 @@
+<?php
+declare(strict_types=1);
+
+// packageCommon.php centralises helpers shared across packaging utilities.
+// The helpers keep with the KISS rule so every script uses the same flow.
+
+// PACKAGE_EXCLUDES mirrors the runtime paths we never archive.
+const PACKAGE_EXCLUDES = [
+    '/dev/*',
+    '/proc/*',
+    '/sys/*',
+    '/tmp/*',
+    '/run/*',
+    '/mnt/*',
+    '/media/*',
+    '/lost+found',
+];
+
+// fail prints an error to STDERR and exits with a non-zero status code.
+function fail(string $message, int $exitCode = 1): void
+{
+    fwrite(STDERR, $message . "\n");
+    exit($exitCode);
+}
+
+// commandExists checks whether a binary is reachable in the PATH.
+function commandExists(string $binary): bool
+{
+    $escaped = escapeshellarg($binary);
+    $result = shell_exec("command -v {$escaped} 2>/dev/null");
+    return is_string($result) && trim($result) !== '';
+}
+
+// ensureBinary enforces that a required binary is present before running.
+function ensureBinary(string $binary): void
+{
+    if (!commandExists($binary)) {
+        fail("Required command '{$binary}' not found in PATH.");
+    }
+}
+
+// ensureDirectory guarantees that a directory exists before use.
+function ensureDirectory(string $path): void
+{
+    if (is_dir($path)) {
+        return;
+    }
+
+    if (!mkdir($path, 0755, true) && !is_dir($path)) {
+        fail("Unable to create directory: {$path}");
+    }
+}
+
+// sanitiseIdentifier normalises filenames used for generated archives.
+function sanitiseIdentifier(string $value): string
+{
+    $clean = preg_replace('/[^A-Za-z0-9._-]/', '-', $value);
+    return $clean === null ? 'target' : trim($clean, '-');
+}
+
+// defaultOutputPath builds a timestamped archive path for a workload.
+function defaultOutputPath(string $label, string $identifier): string
+{
+    $safe = sanitiseIdentifier($identifier);
+    if ($safe === '') {
+        $safe = 'target';
+    }
+
+    $timestamp = date('Ymd-His');
+    return getcwd() . DIRECTORY_SEPARATOR . "{$label}-{$safe}-{$timestamp}.tar.gz";
+}
+
+// tarExcludeArguments returns the shared --exclude arguments for tar.
+function tarExcludeArguments(): array
+{
+    $args = [];
+    foreach (PACKAGE_EXCLUDES as $pattern) {
+        $args[] = '--exclude=' . escapeshellarg($pattern);
+    }
+    return $args;
+}
+
+// tarBaseCommandPrefix supplies the reusable tar options and excludes.
+function tarBaseCommandPrefix(): string
+{
+    $parts = array_merge(
+        ['tar', '--numeric-owner', '--xattrs', '--acls', '--one-file-system'],
+        tarExcludeArguments()
+    );
+    return implode(' ', $parts);
+}
+
+// tokenizeArgumentString splits a shell-like string into individual tokens.
+function tokenizeArgumentString(string $value): array
+{
+    $tokens = [];
+
+    if ($value === '') {
+        return $tokens;
+    }
+
+    $pattern = "/\"([^\"]*)\"|'([^']*)'|([^\\s\"']+)/";
+    if (preg_match_all($pattern, $value, $matches)) {
+        foreach ($matches[0] as $index => $_) {
+            $double = $matches[1][$index] ?? '';
+            if ($double !== '') {
+                $tokens[] = stripcslashes($double);
+                continue;
+            }
+
+            $single = $matches[2][$index] ?? '';
+            if ($single !== '') {
+                $tokens[] = $single;
+                continue;
+            }
+
+            $plain = $matches[3][$index] ?? '';
+            if ($plain !== '') {
+                $tokens[] = $plain;
+            }
+        }
+    }
+
+    if (count($tokens) === 0 && trim($value) !== '') {
+        $tokens[] = trim($value);
+    }
+
+    $normalised = [];
+    $carry = null;
+
+    foreach ($tokens as $token) {
+        if ($carry !== null) {
+            $normalised[] = $carry . $token;
+            $carry = null;
+            continue;
+        }
+
+        if ($token !== '=' && substr($token, -1) === '=') {
+            // Hold tokens like "ProxyCommand=" until the value arrives.
+            $carry = $token;
+            continue;
+        }
+
+        $normalised[] = $token;
+    }
+
+    if ($carry !== null) {
+        $normalised[] = $carry;
+    }
+
+    return $normalised;
+}

--- a/tools/templateCloneImage.php
+++ b/tools/templateCloneImage.php
@@ -1,0 +1,333 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+// templateCloneImage.php clones a local disk image into a template archive.
+// The implementation matches the Bash tooling flow while staying maintainable.
+
+require_once __DIR__ . '/lib/packageCommon.php';
+
+// Shared state tracks mounted resources for final cleanup.
+$IMAGE_STATE = [
+    'device' => '',
+    'type' => '',
+    'mountDir' => '',
+];
+
+// Register cleanup immediately so unexpected exits free resources.
+register_shutdown_function(static function () use (&$IMAGE_STATE): void {
+    performCleanup($IMAGE_STATE);
+});
+
+// printUsage summarises supported flags for the operator.
+function printUsage(): void
+{
+    $script = basename(__FILE__);
+    echo "Usage: {$script} --image <path> [--output <file>] [--partition <num>]\\n";
+    echo "\n";
+    echo "Options:\n";
+    echo "  --image <path>       Local raw or qcow2 image file.\n";
+    echo "  --output <file>      Destination archive path.\n";
+    echo "  --partition <value>  Partition number or device path.\n";
+    echo "  --help               Show this message.\n";
+}
+
+// parseArguments converts argv entries into a structured config array.
+function parseArguments(array $argv): array
+{
+    $config = [
+        'image' => '',
+        'output' => '',
+        'partition' => '',
+    ];
+
+    for ($i = 1; $i < count($argv); $i++) {
+        $arg = $argv[$i];
+        switch ($arg) {
+            case '--image':
+                $config['image'] = $argv[++$i] ?? '';
+                break;
+            case '--output':
+                $config['output'] = $argv[++$i] ?? '';
+                break;
+            case '--partition':
+                $config['partition'] = $argv[++$i] ?? '';
+                break;
+            case '--help':
+                printUsage();
+                exit(0);
+            default:
+                fail("Unknown argument '{$arg}'.");
+        }
+    }
+
+    if ($config['image'] === '') {
+        printUsage();
+        fail('Missing required --image value.');
+    }
+
+    if (!is_file($config['image'])) {
+        fail("Image file not found: {$config['image']}");
+    }
+
+    if ($config['output'] === '') {
+        $config['output'] = defaultOutputPath('image', basename($config['image']));
+    }
+
+    return $config;
+}
+
+// requireRoot ensures the process has privileges to attach loop devices.
+function requireRoot(): void
+{
+    if (function_exists('posix_geteuid') && posix_geteuid() !== 0) {
+        fail('Root privileges are required.');
+    }
+}
+
+// runCommand wraps exec() while providing uniform error handling.
+function runCommand(string $command, bool $allowFailure = false): array
+{
+    $output = [];
+    exec($command . ' 2>&1', $output, $status);
+    if ($status !== 0 && !$allowFailure) {
+        fail("Command failed ({$command}) with exit code {$status}.");
+    }
+    return ['status' => $status, 'output' => $output];
+}
+
+// detectImageType uses qemu-img to decide between raw and qcow2.
+function detectImageType(string $image): string
+{
+    $result = runCommand('qemu-img info ' . escapeshellarg($image));
+    $info = strtolower(implode("\n", $result['output']));
+    return strpos($info, 'file format: qcow2') !== false ? 'qcow2' : 'raw';
+}
+
+// attachRaw uses losetup --partscan to expose raw partitions.
+function attachRaw(string $image, array &$state): string
+{
+    $command = 'losetup --find --show --partscan --read-only ' . escapeshellarg($image);
+    $result = runCommand($command);
+    $device = trim($result['output'][0] ?? '');
+    if ($device === '') {
+        fail('losetup did not return a device path.');
+    }
+    if (!waitForDeviceReadiness($device)) {
+        runCommand('losetup -d ' . escapeshellarg($device), true);
+        fail('Timed out waiting for partitions on attached loop device.');
+    }
+    $state['device'] = $device;
+    $state['type'] = 'raw';
+    return $device;
+}
+
+// attachQcow2 connects the qcow2 image through qemu-nbd.
+function attachQcow2(string $image, array &$state): string
+{
+    runCommand('modprobe nbd max_part=16', true);
+    $candidates = glob('/dev/nbd*');
+    if ($candidates === false) {
+        fail('Unable to enumerate nbd devices.');
+    }
+
+    foreach ($candidates as $device) {
+        if (!preg_match('/^\/dev\/nbd[0-9]+$/', $device)) {
+            continue;
+        }
+        $command = 'qemu-nbd --connect=' . escapeshellarg($device) . ' --read-only ' . escapeshellarg($image);
+        $result = runCommand($command, true);
+        if ($result['status'] === 0) {
+            $state['device'] = $device;
+            $state['type'] = 'qcow2';
+            if (!waitForDeviceReadiness($device)) {
+                runCommand('qemu-nbd --disconnect ' . escapeshellarg($device), true);
+                $state['device'] = '';
+                $state['type'] = '';
+                continue;
+            }
+            return $device;
+        }
+    }
+
+    fail('Unable to allocate an nbd device.');
+}
+
+// waitForDeviceReadiness pauses until partitions or filesystems appear.
+function waitForDeviceReadiness(string $device, int $timeoutSeconds = 10): bool
+{
+    $deadline = time() + $timeoutSeconds;
+    $baseName = basename($device);
+
+    while (time() <= $deadline) {
+        $result = runCommand('lsblk -ln -o NAME,TYPE,FSTYPE ' . escapeshellarg($device), true);
+        if ($result['status'] === 0) {
+            foreach ($result['output'] as $line) {
+                $parts = preg_split('/\s+/', trim($line));
+                $name = $parts[0] ?? '';
+                $type = $parts[1] ?? '';
+                $fstype = $parts[2] ?? '';
+                if ($type === 'part' && $fstype !== '') {
+                    return true;
+                }
+                if ($name === $baseName && $fstype !== '') {
+                    return true;
+                }
+            }
+        }
+
+        // Sleep briefly so udev can create any pending device nodes.
+        usleep(200000);
+    }
+
+    return false;
+}
+
+// selectPartition picks the partition path either manually or automatically.
+function selectPartition(string $baseDevice, string $override): string
+{
+    if ($override !== '') {
+        if ($override[0] === '/') {
+            $candidate = $override;
+        } else {
+            $candidate = $baseDevice . 'p' . $override;
+        }
+        if (!is_readable($candidate)) {
+            fail("Specified partition not found: {$candidate}");
+        }
+        return $candidate;
+    }
+
+    $command = 'lsblk -ln -o NAME,TYPE,FSTYPE ' . escapeshellarg($baseDevice);
+    $result = runCommand($command);
+
+    $baseName = preg_replace('/^\\/dev\\//', '', $baseDevice);
+    $baseCandidate = '';
+
+    foreach ($result['output'] as $line) {
+        $parts = preg_split('/\s+/', trim($line));
+        $name = $parts[0] ?? '';
+        $type = $parts[1] ?? '';
+        $fstype = $parts[2] ?? '';
+        if ($type === 'part' && $fstype !== '') {
+            return '/dev/' . $name;
+        }
+        // Track the base device when it exposes a filesystem directly.
+        if ($name === $baseName && $fstype !== '') {
+            $baseCandidate = '/dev/' . $name;
+        }
+    }
+
+    if ($baseCandidate !== '') {
+        return $baseCandidate;
+    }
+
+    fail('Could not auto-detect a mountable partition.');
+}
+
+// mountPartition mounts the partition read-only and records the directory.
+function mountPartition(string $partition, array &$state): string
+{
+    $mountDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'mcx-image-' . uniqid();
+    ensureDirectory($mountDir);
+    runCommand('mount -o ro ' . escapeshellarg($partition) . ' ' . escapeshellarg($mountDir));
+    $state['mountDir'] = $mountDir;
+    return $mountDir;
+}
+
+// determineCompressor selects pigz when available and falls back to gzip.
+function determineCompressor(): string
+{
+    if (commandExists('pigz')) {
+        return 'pigz -9';
+    }
+    ensureBinary('gzip');
+    fwrite(STDERR, "pigz not found locally, falling back to gzip.\n");
+    return 'gzip -9';
+}
+
+// createArchive compresses the mounted root filesystem into a tarball.
+function createArchive(string $mountDir, string $output, string $compressor): void
+{
+    ensureDirectory(dirname($output));
+    $command = tarBaseCommandPrefix() .
+        ' -I ' . escapeshellarg($compressor) .
+        ' -cf ' . escapeshellarg($output) .
+        ' -C ' . escapeshellarg($mountDir) . ' .';
+
+    runCommand($command);
+}
+
+// performCleanup unmounts and detaches resources registered in state.
+function performCleanup(array &$state): void
+{
+    if ($state['mountDir'] !== '' && is_dir($state['mountDir'])) {
+        if (isMounted($state['mountDir'])) {
+            runCommand('umount ' . escapeshellarg($state['mountDir']), true);
+        }
+        @rmdir($state['mountDir']);
+        $state['mountDir'] = '';
+    }
+
+    if ($state['device'] !== '') {
+        if ($state['type'] === 'raw') {
+            runCommand('losetup -d ' . escapeshellarg($state['device']), true);
+        } elseif ($state['type'] === 'qcow2') {
+            runCommand('qemu-nbd --disconnect ' . escapeshellarg($state['device']), true);
+        }
+        $state['device'] = '';
+        $state['type'] = '';
+    }
+}
+
+// isMounted checks /proc/mounts to confirm a mountpoint is active.
+function isMounted(string $path): bool
+{
+    $mounts = @file('/proc/mounts', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    if ($mounts === false) {
+        return false;
+    }
+    foreach ($mounts as $entry) {
+        $parts = preg_split('/\s+/', trim($entry));
+        if (($parts[1] ?? '') === $path) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// main executes the detection, mounting, and archiving workflow.
+function main(array $argv): void
+{
+    global $IMAGE_STATE;
+
+    requireRoot();
+    ensureBinary('qemu-img');
+    ensureBinary('tar');
+    ensureBinary('mount');
+    ensureBinary('losetup');
+    ensureBinary('lsblk');
+
+    $config = parseArguments($argv);
+    $type = detectImageType($config['image']);
+
+    if ($type === 'qcow2') {
+        ensureBinary('qemu-nbd');
+        $device = attachQcow2($config['image'], $IMAGE_STATE);
+    } else {
+        $device = attachRaw($config['image'], $IMAGE_STATE);
+    }
+
+    $partition = selectPartition($device, $config['partition']);
+    $mountDir = mountPartition($partition, $IMAGE_STATE);
+
+    $compressor = determineCompressor();
+    createArchive($mountDir, $config['output'], $compressor);
+
+    echo "Archive stored at {$config['output']}\n";
+}
+
+// Execute only when run directly from the command line.
+if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'] ?? '')) {
+    main($argv);
+}

--- a/tools/templateCloneRemote.php
+++ b/tools/templateCloneRemote.php
@@ -1,0 +1,204 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+// templateCloneRemote.php streams a live system archive over SSH for templates.
+// The flow mirrors cloneLiveSystem.sh but keeps orchestration inside PHP.
+
+require_once __DIR__ . '/lib/packageCommon.php';
+
+// printUsage describes the positional arguments and optional SSH flags.
+function printUsage(): void
+{
+    $script = basename(__FILE__);
+    echo "Usage: {$script} <user@host> <output|-> [--ssh-option <option>]... [--force]\\n";
+    echo "\n";
+    echo "Arguments:\n";
+    echo "  <user@host>   Remote SSH endpoint providing the root filesystem.\n";
+    echo "  <output|->    Destination path or '-' to stream to STDOUT.\n";
+    echo "\n";
+    echo "Options:\n";
+    echo "  --ssh-option <option>  Extra ssh(1) option, may repeat.\n";
+    echo "  --force               Overwrite an existing output file.\n";
+    echo "  --help                 Show this help message.\n";
+}
+
+// parseArguments collects positionals and optional SSH flags into config.
+function parseArguments(array $argv): array
+{
+    $config = [
+        'remote' => '',
+        'output' => '',
+        'sshOptions' => [],
+        'force' => false,
+    ];
+
+    $positionals = [];
+    for ($i = 1; $i < count($argv); $i++) {
+        $arg = $argv[$i];
+        if ($arg === '--ssh-option') {
+            $option = $argv[++$i] ?? '';
+            if ($option === '') {
+                fail('Missing value for --ssh-option.');
+            }
+            // Tokenise values so combined flags like "-p 2222" remain valid.
+            $tokens = tokenizeArgumentString($option);
+            if (count($tokens) === 0) {
+                fail('Empty --ssh-option value provided.');
+            }
+            foreach ($tokens as $token) {
+                $config['sshOptions'][] = $token;
+            }
+            continue;
+        }
+
+        // Allow forced overwrite when rerunning against the same target.
+        if ($arg === '--force') {
+            $config['force'] = true;
+            continue;
+        }
+
+        if ($arg === '--help') {
+            printUsage();
+            exit(0);
+        }
+
+        if (substr($arg, 0, 2) === '--') {
+            fail("Unknown argument '{$arg}'.");
+        }
+
+        $positionals[] = $arg;
+    }
+
+    if (count($positionals) < 2) {
+        printUsage();
+        fail('Source and output arguments are required.');
+    }
+
+    $config['remote'] = $positionals[0];
+    $config['output'] = $positionals[1];
+
+    return $config;
+}
+
+// buildRemoteScript assembles the compression pipeline executed remotely.
+function buildRemoteScript(): string
+{
+    $tarCommand = tarBaseCommandPrefix() . ' -cf - /';
+
+    $lines = [
+        'set -euo pipefail',
+        'if command -v pigz >/dev/null 2>&1; then',
+        "    COMPRESSOR='pigz -9'",
+        'else',
+        "    COMPRESSOR='gzip -9'",
+        'fi',
+        $tarCommand . " | \$COMPRESSOR",
+    ];
+
+    return implode("\n", $lines) . "\n";
+}
+
+// buildSshCommand prepares the ssh invocation with optional arguments.
+function buildSshCommand(string $remote, array $options): string
+{
+    $parts = ['ssh'];
+    // Options arrive pre-tokenised so they can include flags and values.
+    foreach ($options as $option) {
+        $parts[] = $option;
+    }
+    $parts[] = $remote;
+    $parts[] = 'bash -s';
+
+    $escaped = [];
+    foreach ($parts as $part) {
+        $escaped[] = escapeshellarg($part);
+    }
+
+    return implode(' ', $escaped);
+}
+
+// resolveOutput decides whether we stream to STDOUT or a named file.
+function resolveOutput(string $output, bool $force): array
+{
+    if ($output === '-' || strtolower($output) === 'stdout') {
+        return [
+            'target' => 'php://stdout',
+            'label' => 'STDOUT',
+            'isStdout' => true,
+        ];
+    }
+
+    if (strpos($output, 'php://') === 0) {
+        return [
+            'target' => $output,
+            'label' => $output,
+            'isStdout' => false,
+        ];
+    }
+
+    $directory = dirname($output);
+    ensureDirectory($directory);
+
+    // Guard against silent overwrites unless the operator opts in.
+    if (file_exists($output) && !$force) {
+        fail("Output file already exists: {$output}. Use --force to overwrite.");
+    }
+
+    return [
+        'target' => $output,
+        'label' => $output,
+        'isStdout' => false,
+    ];
+}
+
+// streamArchive pipes the remote tarball into the resolved destination.
+function streamArchive(array $config): array
+{
+    $destination = resolveOutput($config['output'], $config['force']);
+    $command = buildSshCommand($config['remote'], $config['sshOptions']);
+    $remoteScript = buildRemoteScript();
+
+    $descriptors = [
+        0 => ['pipe', 'w'],
+        1 => ['file', $destination['target'], 'w'],
+        2 => ['file', 'php://stderr', 'w'],
+    ];
+
+    $process = proc_open($command, $descriptors, $pipes);
+    if (!is_resource($process)) {
+        fail('Unable to start ssh process.');
+    }
+
+    fwrite($pipes[0], $remoteScript);
+    fclose($pipes[0]);
+
+    $exitCode = proc_close($process);
+    if ($exitCode !== 0) {
+        fail("Streaming failed with exit code {$exitCode}.");
+    }
+
+    return $destination;
+}
+
+// main validates requirements, performs streaming, and reports status.
+function main(array $argv): void
+{
+    ensureBinary('ssh');
+
+    $config = parseArguments($argv);
+    $destination = streamArchive($config);
+
+    $message = 'Archive stream completed';
+    if ($destination['isStdout']) {
+        fwrite(STDERR, $message . " (STDOUT).\n");
+        return;
+    }
+
+    echo $message . ' at ' . $destination['label'] . "\n";
+}
+
+// Execute only when the script is run directly.
+if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'] ?? '')) {
+    main($argv);
+}


### PR DESCRIPTION
## Summary
- add a shared shell-style tokenizer so ssh options are forwarded correctly and protect remote captures with an optional --force flag
- mount disk images in read-only mode, wait for their partitions to appear, and allow filesystem-only images to be archived
- reuse the shared exclusion list in templateAssemble, forward ssh options through rsync, and refresh the documentation to cover the new flags
- expand the tooling README with a quick-reference overview plus synopses for each script so operators can find the right entry point quickly

## Testing
- php -l tools/lib/packageCommon.php
- php -l tools/templateCloneRemote.php
- php -l tools/templateCloneImage.php
- php -l tools/templateAssemble.php
- phpcbf --standard=PSR12 tools/lib/packageCommon.php tools/templateCloneRemote.php tools/templateCloneImage.php tools/templateAssemble.php *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cee62c8d4c832f97a50c26a51a02a9