### PR TITLE
Add comprehensive CommonHelpers tests

### DIFF
--- a/tests/Lib/Common/CommonHelpersTest.php
+++ b/tests/Lib/Common/CommonHelpersTest.php
@@ -1,0 +1,356 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Lib\Common;
+
+use Lib\Common\System;
+use PHPUnit\Framework\TestCase;
+
+// CommonHelpersTest validates the legacy CommonHelpers facade stays predictable for callers.
+final class CommonHelpersTest extends TestCase
+{
+    // Each logging wrapper should forward to Logging and keep the expected format intact.
+    /**
+     * @dataProvider provideLoggingWrappers
+     */
+    public function testLoggingHelpersProxyToLogging(string $method, string $level, string $message): void
+    {
+        // Build the invocation so the isolated interpreter only runs the requested helper.
+        $invocation = sprintf(
+            '\\Common\\Lib\\CommonHelpers::%s(%s);',
+            $method,
+            var_export($message, true)
+        );
+
+        // Execute the helper via a fresh PHP process to collect stdout without polluting PHPUnit.
+        [$output, $status] = $this->invokeCommonHelpersInIsolatedProcess($invocation);
+
+        // Confirm we saw a clean exit and a correctly formatted log line with the original message.
+        $this->assertSame(0, $status);
+        $this->assertMatchesRegularExpression($this->buildLogPattern($level, $message), $output);
+    }
+
+    // provideLoggingWrappers supplies a wide mix of log levels and message shapes to broaden coverage.
+    public function provideLoggingWrappers(): array
+    {
+        return [
+            'info simple' => ['logInfo', 'INFO', 'system online'],
+            'info punctuation' => ['logInfo', 'INFO', 'phase-1 ready'],
+            'info unicode' => ['logInfo', 'INFO', 'café ready'],
+            'info numbers' => ['logInfo', 'INFO', 'slot #12 engaged'],
+            'warn simple' => ['logWarn', 'WARN', 'retry window open'],
+            'warn path' => ['logWarn', 'WARN', 'disk [/dev/sda] near full'],
+            'warn uppercase' => ['logWarn', 'WARN', 'TEMPERATURE HIGH'],
+            'warn quoted' => ['logWarn', 'WARN', 'user "deploy" delayed'],
+            'error simple' => ['logError', 'ERROR', 'fatal mismatch observed'],
+            'error path' => ['logError', 'ERROR', 'failed to open /etc/passwd'],
+            'error percent' => ['logError', 'ERROR', '99% done but failing'],
+            'error colon' => ['logError', 'ERROR', 'service: offline'],
+        ];
+    }
+
+    // die() should log the message then exit with the requested status code for every scenario.
+    /**
+     * @dataProvider provideExitCodes
+     */
+    public function testDieExitsWithProvidedStatus(int $code, string $messageFragment): void
+    {
+        // Compose the die() call so the test can assert the resulting status and stderr-friendly text.
+        $invocation = sprintf(
+            '\\Common\\Lib\\CommonHelpers::die(%s, %d);',
+            var_export($messageFragment, true),
+            $code
+        );
+
+        // Launch the helper out-of-process to avoid halting the main PHPUnit execution flow.
+        [$output, $status] = $this->invokeCommonHelpersInIsolatedProcess($invocation);
+
+        // Expect the exit code to match while the log output records the provided message fragment.
+        $this->assertSame($code, $status);
+        $this->assertStringContainsString('[ERROR]', $output);
+        $this->assertStringContainsString($messageFragment, $output);
+    }
+
+    // provideExitCodes exercises several realistic exit statuses to keep the behaviour predictable.
+    public function provideExitCodes(): array
+    {
+        return [
+            'default one' => [1, 'primary failure'],
+            'config missing' => [2, 'config missing'],
+            'retry exhausted' => [7, 'retry limit exceeded'],
+            'unexpected branch' => [42, 'unexpected branch reached'],
+            'fatal signal mimic' => [111, 'fatal signal mimic'],
+        ];
+    }
+
+    // requireCommand should silently continue for every commonly provisioned binary we rely on.
+    /**
+     * @dataProvider provideAvailableCommands
+     */
+    public function testRequireCommandSucceedsForAvailableCommands(string $command): void
+    {
+        // Prepare the invocation so we can observe that execution flows past the helper call.
+        $invocation = sprintf(
+            '\\Common\\Lib\\CommonHelpers::requireCommand(%s); echo "ok";',
+            var_export($command, true)
+        );
+
+        // Execute in isolation to mimic real usage while keeping PHPUnit alive during failure modes.
+        [$output, $status] = $this->invokeCommonHelpersInIsolatedProcess($invocation);
+
+        // Confirm the exit stayed zero and the sentinel output shows control returned to the caller.
+        $this->assertSame(0, $status);
+        $this->assertSame('ok', $output);
+    }
+
+    // provideAvailableCommands lists binaries bundled in every test container for stable assertions.
+    public function provideAvailableCommands(): array
+    {
+        return [
+            'shell' => ['sh'],
+            'env' => ['env'],
+            'php' => ['php'],
+            'ls' => ['ls'],
+            'cat' => ['cat'],
+        ];
+    }
+
+    // requireCommand must stop execution when the target binary cannot be discovered.
+    /**
+     * @dataProvider provideMissingCommands
+     */
+    public function testRequireCommandFailsForMissingCommands(string $command): void
+    {
+        // Invoke the helper with an obviously invalid command to trigger the fail-fast path.
+        $invocation = sprintf(
+            '\\Common\\Lib\\CommonHelpers::requireCommand(%s);',
+            var_export($command, true)
+        );
+
+        // Run the helper in an isolated PHP instance to capture the exit code and log output.
+        [$output, $status] = $this->invokeCommonHelpersInIsolatedProcess($invocation);
+
+        // Assert we exited with the default fatal code while the error text references the command.
+        $this->assertSame(1, $status);
+        $this->assertStringContainsString('[ERROR]', $output);
+        $this->assertStringContainsString($command, $output);
+    }
+
+    // provideMissingCommands covers whitespace, shell tricks, and nonsense binaries to harden validation.
+    public function provideMissingCommands(): array
+    {
+        return [
+            'gibberish one' => ['mcx-missing-one'],
+            'gibberish two' => ['mcx-missing-two'],
+            'gibberish three' => ['mcx-missing-three'],
+            'gibberish four' => ['mcx-missing-four'],
+            'gibberish five' => ['mcx-missing-five'],
+            'empty string' => [''],
+            'spaces only' => ['   '],
+            'fake absolute' => ['/tmp/mcx/definitely-not-real'],
+            'subshell attempt' => ['$(mcx-never-runs)'],
+            'wild command' => ['DROP TABLE'],
+        ];
+    }
+
+    // requireReadableFile should allow execution to continue when the path resolves to a readable file.
+    /**
+     * @dataProvider provideReadableFilePaths
+     */
+    public function testRequireReadableFileAcceptsPaths(string $path): void
+    {
+        // Wrap the helper call so we can detect that control reaches the sentinel echo afterwards.
+        $invocation = sprintf(
+            '\\Common\\Lib\\CommonHelpers::requireReadableFile(%s); echo "ok";',
+            var_export($path, true)
+        );
+
+        // Execute the helper in isolation because the failure branch terminates the interpreter.
+        [$output, $status] = $this->invokeCommonHelpersInIsolatedProcess($invocation);
+
+        // Ensure the exit remained successful and that the sentinel confirms continued execution.
+        $this->assertSame(0, $status);
+        $this->assertSame('ok', $output);
+    }
+
+    // provideReadableFilePaths references canonical repository files that should remain readable.
+    public function provideReadableFilePaths(): array
+    {
+        return [
+            'common helpers' => [$this->resolvePath(__DIR__ . '/../../../src/Common/Lib/Common.php')],
+            'logging helper' => [$this->resolvePath(__DIR__ . '/../../../src/Lib/Common/Logging.php')],
+            'system helper' => [$this->resolvePath(__DIR__ . '/../../../src/Lib/Common/System.php')],
+        ];
+    }
+
+    // requireReadableFile must reject unreadable, missing, or malformed paths every time they appear.
+    /**
+     * @dataProvider provideUnreadableFileScenarios
+     */
+    public function testRequireReadableFileRejectsInvalidPaths(callable $scenario): void
+    {
+        // Prepare the scenario, capturing the generated path and optional cleanup hook.
+        [$path, $cleanup] = $scenario();
+
+        try {
+            // Execute the helper so we can assert it exits and logs the problematic path reference.
+            $invocation = sprintf(
+                '\\Common\\Lib\\CommonHelpers::requireReadableFile(%s);',
+                var_export($path, true)
+            );
+
+            [$output, $status] = $this->invokeCommonHelpersInIsolatedProcess($invocation);
+
+            // Validate that we exited with the fatal code and surfaced the expected error messaging.
+            $this->assertSame(1, $status);
+            $this->assertStringContainsString('[ERROR]', $output);
+            $this->assertStringContainsString('Required file', $output);
+        } finally {
+            // Always run the cleanup to avoid leaking broken symlinks or permission-altered directories.
+            if ($cleanup !== null) {
+                $cleanup();
+            }
+        }
+    }
+
+    // provideUnreadableFileScenarios creates multiple failure modes so validation stays defensive.
+    public function provideUnreadableFileScenarios(): array
+    {
+        return [
+            'missing absolute' => [static fn (): array => ['/definitely/not/here', null]],
+            'missing relative' => [static fn (): array => [__DIR__ . '/missing-file.txt', null]],
+            'empty string' => [static fn (): array => ['', null]],
+            'spaces only' => [static fn (): array => ['   ', null]],
+            'broken symlink' => [function (): array {
+                $path = sys_get_temp_dir() . '/mcx_broken_symlink';
+                @unlink($path);
+                symlink('/definitely/not/here', $path);
+                $cleanup = static function () use ($path): void {
+                    @unlink($path);
+                };
+                return [$path, $cleanup];
+            }],
+            'unicode missing path' => [static fn (): array => [sys_get_temp_dir() . '/不存在-file', null]],
+        ];
+    }
+
+    // requireNonEmpty should allow non-empty strings regardless of whether callers supply a label.
+    /**
+     * @dataProvider provideNonEmptyValues
+     */
+    public function testRequireNonEmptyAcceptsValues(string $value, ?string $name, bool $includeName): void
+    {
+        // Build the helper invocation while optionally including the custom label parameter.
+        $call = $includeName
+            ? sprintf('\\Common\\Lib\\CommonHelpers::requireNonEmpty(%s, %s);', var_export($value, true), var_export($name, true))
+            : sprintf('\\Common\\Lib\\CommonHelpers::requireNonEmpty(%s);', var_export($value, true));
+
+        // Append a sentinel echo so we can confirm execution returns to the caller after validation.
+        $invocation = $call . ' echo "ok";';
+
+        // Run the helper via a separate PHP instance so exits do not terminate the PHPUnit harness.
+        [$output, $status] = $this->invokeCommonHelpersInIsolatedProcess($invocation);
+
+        // Successful paths should keep the exit code at zero and surface the sentinel response.
+        $this->assertSame(0, $status);
+        $this->assertSame('ok', $output);
+    }
+
+    // provideNonEmptyValues spans plain, spaced, and unicode strings with and without explicit labels.
+    public function provideNonEmptyValues(): array
+    {
+        return [
+            'simple default label' => ['ready', null, false],
+            'spaced default label' => ['  trimmed  ', null, false],
+            'unicode default label' => ['naïve', null, false],
+            'simple named label' => ['ready', 'hostname', true],
+            'unicode named label' => ['пример', 'описание', true],
+        ];
+    }
+
+    // requireNonEmpty should exit when presented with empty values, using the right label each time.
+    /**
+     * @dataProvider provideEmptyValues
+     */
+    public function testRequireNonEmptyFailsForEmptyValues(string $value, ?string $name, bool $includeName, string $expectedLabel): void
+    {
+        // Build the helper call, omitting the label when the scenario expects the default placeholder.
+        $call = $includeName
+            ? sprintf('\\Common\\Lib\\CommonHelpers::requireNonEmpty(%s, %s);', var_export($value, true), var_export($name, true))
+            : sprintf('\\Common\\Lib\\CommonHelpers::requireNonEmpty(%s);', var_export($value, true));
+
+        // Execute the helper so we can assert on both the exit code and the emitted error messaging.
+        [$output, $status] = $this->invokeCommonHelpersInIsolatedProcess($call);
+
+        // Every failure should map to exit code one and reference the label that was evaluated.
+        $this->assertSame(1, $status);
+        $this->assertStringContainsString('[ERROR]', $output);
+        $this->assertStringContainsString(sprintf("Required value '%s' is empty.", $expectedLabel), $output);
+    }
+
+    // provideEmptyValues focuses on blank strings, whitespace, and explicit labels to guard regressions.
+    public function provideEmptyValues(): array
+    {
+        return [
+            'empty default' => ['', null, false, 'value'],
+            'empty named' => ['', 'hostname', true, 'hostname'],
+            'empty explicit label' => ['', '', true, ''],
+            'empty multi word label' => ['', 'pipeline stage', true, 'pipeline stage'],
+        ];
+    }
+
+    // buildLogPattern mirrors LoggingTest so log format expectations stay aligned between suites.
+    private function buildLogPattern(string $level, string $message): string
+    {
+        $escapedLevel = preg_quote($level, '/');
+        $escapedMessage = preg_quote($message, '/');
+        return sprintf('/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z \\[%s\\] %s$/', $escapedLevel, $escapedMessage);
+    }
+
+    // invokeCommonHelpersInIsolatedProcess centralises the boilerplate for spawning isolated PHP runs.
+    private function invokeCommonHelpersInIsolatedProcess(string $invocation): array
+    {
+        $script = sprintf(
+            'require_once %s; require_once %s; %s',
+            var_export($this->getBootstrapPath(), true),
+            var_export($this->getCommonHelpersPath(), true),
+            $invocation
+        );
+
+        $output = System::capture([PHP_BINARY, '-d', 'display_errors=0', '-r', $script], $status);
+        return [$output, $status];
+    }
+
+    // getBootstrapPath resolves the shared bootstrap loader for isolated interpreter execution.
+    private function getBootstrapPath(): string
+    {
+        $path = realpath(__DIR__ . '/../../bootstrap.php');
+        if ($path === false) {
+            $this->fail('Unable to resolve bootstrap path for CommonHelpers tests.');
+        }
+
+        return $path;
+    }
+
+    // getCommonHelpersPath finds the legacy CommonHelpers definition for inclusion in isolated runs.
+    private function getCommonHelpersPath(): string
+    {
+        $path = realpath(__DIR__ . '/../../../src/Common/Lib/Common.php');
+        if ($path === false) {
+            $this->fail('Unable to resolve CommonHelpers path for inclusion.');
+        }
+
+        return $path;
+    }
+
+    // resolvePath wraps realpath() so data providers can reuse the consistent failure handling logic.
+    private function resolvePath(string $path): string
+    {
+        $resolved = realpath($path);
+        if ($resolved === false) {
+            $this->fail(sprintf('Unable to resolve path: %s', $path));
+        }
+
+        return $resolved;
+    }
+}

--- a/tests/Lib/Common/LoggingTest.php
+++ b/tests/Lib/Common/LoggingTest.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Lib\Common;
+
+use Lib\Common\System;
+use PHPUnit\Framework\TestCase;
+
+// LoggingTest verifies the timestamped logging helpers remain stable even with unusual messages.
+final class LoggingTest extends TestCase
+{
+    // Each logger should emit a UTC timestamp, the level tag, and the original message payload.
+    /**
+     * @dataProvider provideLevelsAndMessages
+     */
+    public function testLoggersEmitTimestampedLines(string $method, string $level, string $message): void
+    {
+        $output = $this->executeLoggingCall($method, $message);
+        $this->assertLogLineMatches($output, $level, $message);
+    }
+
+    // provideLevelsAndMessages covers typical phrases plus tricky payloads like multiline strings.
+    public function provideLevelsAndMessages(): array
+    {
+        return [
+            'info basic' => ['info', 'INFO', 'booting sequence'],
+            'warn spaced' => ['warn', 'WARN', 'late stage retry window'],
+            'error special chars' => ['error', 'ERROR', 'path [/tmp/volume] reported "busy"'],
+            'info multiline' => ['info', 'INFO', "line-one\nline-two"],
+        ];
+    }
+
+    // Calling an undefined logger should bubble the PHP fatal error back to the caller.
+    public function testUnknownLoggingMethodSurfacesPhpError(): void
+    {
+        $script = sprintf(
+            'require_once %s; \\Lib\\Common\\Logging::%s(%s);',
+            var_export($this->getLoggingPath(), true),
+            'missing',
+            var_export('boom', true)
+        );
+
+        $output = System::capture([PHP_BINARY, '-d', 'display_errors=1', '-r', $script], $status);
+        $this->assertNotSame(0, $status);
+        $this->assertStringContainsString('Call to undefined method', $output);
+    }
+
+    // executeLoggingCall runs the requested logger in a fresh CLI PHP to capture stdout reliably.
+    private function executeLoggingCall(string $method, string $message): string
+    {
+        $script = sprintf(
+            'require_once %s; \\Lib\\Common\\Logging::%s(%s);',
+            var_export($this->getLoggingPath(), true),
+            $method,
+            var_export($message, true)
+        );
+
+        $output = System::capture([PHP_BINARY, '-r', $script], $status);
+        $this->assertSame(0, $status);
+
+        return $output;
+    }
+
+    // getLoggingPath centralises the realpath lookup so failure messaging stays consistent.
+    private function getLoggingPath(): string
+    {
+        $loggingPath = realpath(__DIR__ . '/../../../src/Lib/Common/Logging.php');
+        if ($loggingPath === false) {
+            $this->fail('Unable to resolve Logging helper path.');
+        }
+
+        return $loggingPath;
+    }
+
+    // assertLogLineMatches standardises the timestamp + level + message verification across cases.
+    private function assertLogLineMatches(string $output, string $level, string $message): void
+    {
+        $pattern = sprintf(
+            '/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z \\[%s\\] %s$/',
+            preg_quote($level, '/'),
+            preg_quote($message, '/')
+        );
+        $this->assertMatchesRegularExpression($pattern, $output);
+    }
+}

--- a/tests/Lib/Common/SystemTest.php
+++ b/tests/Lib/Common/SystemTest.php
@@ -10,29 +10,84 @@ use RuntimeException;
 // SystemTest validates the minimal command helpers without depending on system-specific state.
 final class SystemTest extends TestCase
 {
-    // commandExists should confirm standard shells exist and bogus commands do not.
-    public function testCommandExistsDetectsCommands(): void
+    // commandExists should accept multiple known utilities that are always provisioned.
+    /**
+     * @dataProvider provideExistingCommands
+     */
+    public function testCommandExistsDetectsCommands(string $command): void
     {
-        $this->assertTrue(System::commandExists('sh'));
-        $this->assertFalse(System::commandExists('definitely-not-real'));
+        $this->assertTrue(System::commandExists($command));
     }
 
-    // run streams passthru output, so we focus on exit codes to stay environment-agnostic.
-    public function testRunHandlesExitCodesWithoutTerminating(): void
+    // provideExistingCommands lists binaries that the suite relies on for other checks.
+    public function provideExistingCommands(): array
     {
-        $successStatus = System::run(['true'], false);
-        $this->assertSame(0, $successStatus);
-
-        $failureStatus = System::run(['false'], true);
-        $this->assertNotSame(0, $failureStatus);
+        return [
+            'sh shell' => ['sh'],
+            'env utility' => ['env'],
+            'php interpreter' => ['php'],
+        ];
     }
 
-    // capture should return stdout and report the exit code via the reference parameter.
-    public function testCaptureReturnsOutputAndStatus(): void
+    // commandExists should reject blank and malicious command candidates.
+    /**
+     * @dataProvider provideMissingCommands
+     */
+    public function testCommandExistsRejectsInvalidCommandNames(string $command): void
     {
-        $output = System::capture([PHP_BINARY, '-r', 'echo "ping";'], $status);
-        $this->assertSame('ping', $output);
+        $this->assertFalse(System::commandExists($command));
+    }
+
+    // provideMissingCommands enumerates the surprising inputs we guard against.
+    public function provideMissingCommands(): array
+    {
+        return [
+            'obvious gibberish' => ['definitely-not-real'],
+            'empty string' => [''],
+            'spaces only' => ['   '],
+            'missing absolute path' => ['/bin/definitely-not-real'],
+            'injection looking' => ['$(totally-not-happening)'],
+        ];
+    }
+
+    // run should report success for standard command vectors that exit zero.
+    /**
+     * @dataProvider provideSuccessfulRunCommands
+     */
+    public function testRunHandlesSuccessfulExitCodes(array $command): void
+    {
+        $status = System::run($command);
         $this->assertSame(0, $status);
+    }
+
+    // provideSuccessfulRunCommands keeps the exit-zero cases varied for coverage.
+    public function provideSuccessfulRunCommands(): array
+    {
+        return [
+            'true binary' => [['true']],
+            'shell exit 0' => [['sh', '-c', 'exit 0']],
+            'php inline exit' => [[PHP_BINARY, '-r', 'exit(0);']],
+        ];
+    }
+
+    // run should return the non-zero status for commands that fail in different ways.
+    /**
+     * @dataProvider provideFailingRunCommands
+     */
+    public function testRunSurfacesNonZeroExitCodes(array $command, int $expectedStatus): void
+    {
+        $status = System::run($command);
+        $this->assertSame($expectedStatus, $status);
+    }
+
+    // provideFailingRunCommands illustrates common failure patterns to protect against.
+    public function provideFailingRunCommands(): array
+    {
+        return [
+            'false binary' => [['false'], 1],
+            'shell custom exit' => [['sh', '-c', 'exit 23'], 23],
+            'missing executable' => [['definitely-not-real-command'], 127],
+        ];
     }
 
     // buildCommand must reject empty command vectors so callers supply at least one token.
@@ -42,18 +97,74 @@ final class SystemTest extends TestCase
         System::run([]);
     }
 
-    // runIfCommandExists should silently skip commands that are not present while logging the warning.
-    public function testRunIfCommandExistsSkipsUnknownCommand(): void
+    // run should also accept disallowing failure while still returning zero on success.
+    public function testRunHonoursAllowFailureFlagOnSuccess(): void
     {
-        $result = System::runIfCommandExists('definitely-not-real');
-        $this->assertFalse($result);
+        $status = System::run(['sh', '-c', 'exit 0'], false);
+        $this->assertSame(0, $status);
     }
 
-    // runIfCommandExists should return false when the wrapped command exits with a non-zero status.
-    public function testRunIfCommandExistsPropagatesExitCodes(): void
+    // run should terminate the process when allowFailure is false and the command fails.
+    public function testRunStopsExecutionWhenFailureDisallowed(): void
     {
-        $result = System::runIfCommandExists('sh', ['-c', 'exit 7']);
-        $this->assertFalse($result);
+        $command = ['sh', '-c', 'exit 5'];
+        [$output, $status] = $this->invokeSystemInIsolatedProcess(
+            sprintf('\\Lib\\Common\\System::run(%s, false);', var_export($command, true))
+        );
+
+        $this->assertSame(5, $status);
+        $this->assertStringContainsString('[ERROR]', $output);
+        $this->assertStringContainsString('Command failed', $output);
+    }
+
+    // capture should trim stdout and keep the zero exit code visible to the caller.
+    /**
+     * @dataProvider provideCaptureSuccessCases
+     */
+    public function testCaptureReturnsOutputAndStatus(array $command, string $expectedOutput): void
+    {
+        $output = System::capture($command, $status);
+        $this->assertSame($expectedOutput, $output);
+        $this->assertSame(0, $status);
+    }
+
+    // provideCaptureSuccessCases includes tricky whitespace and newline handling scenarios.
+    public function provideCaptureSuccessCases(): array
+    {
+        return [
+            'php echo' => [[PHP_BINARY, '-r', 'echo "ping";'], 'ping'],
+            'shell multiline' => [['sh', '-c', 'printf "first\\nsecond"'], "first\nsecond"],
+            'shell trimmed spaces' => [['sh', '-c', 'printf "  spaced  "'], 'spaced'],
+        ];
+    }
+
+    // capture must preserve stdout content while surfacing non-zero exit statuses for callers.
+    /**
+     * @dataProvider provideCaptureFailureCases
+     */
+    public function testCaptureReportsOutputForFailingCommands(array $command, string $expectedOutput, int $expectedStatus): void
+    {
+        $output = System::capture($command, $status);
+        $this->assertSame($expectedOutput, $output);
+        $this->assertSame($expectedStatus, $status);
+    }
+
+    // provideCaptureFailureCases lists how stdout behaves when commands fail in messy ways.
+    public function provideCaptureFailureCases(): array
+    {
+        return [
+            'stdout before failure' => [['sh', '-c', 'echo fail; exit 3'], 'fail', 3],
+            'stderr only output' => [['sh', '-c', '>&2 echo error; exit 9'], '', 9],
+            'missing binary' => [['definitely-not-real-command'], '', 127],
+        ];
+    }
+
+    // capture should collapse whitespace-only output to an empty string so callers see no noise.
+    public function testCaptureReturnsEmptyStringWhenCommandOutputsWhitespaceOnly(): void
+    {
+        $output = System::capture(['sh', '-c', "printf '   \n   '"], $status);
+        $this->assertSame('', $output);
+        $this->assertSame(0, $status);
     }
 
     // runIfCommandExists should return true when the executable exists and exits cleanly.
@@ -63,17 +174,98 @@ final class SystemTest extends TestCase
         $this->assertTrue($result);
     }
 
+    // runIfCommandExists should return false when the executable is missing or fails.
+    /**
+     * @dataProvider provideRunIfCommandExistsFailures
+     */
+    public function testRunIfCommandExistsHandlesFailures(string $command, array $args): void
+    {
+        $result = System::runIfCommandExists($command, $args);
+        $this->assertFalse($result);
+    }
+
+    // provideRunIfCommandExistsFailures combines missing binaries and non-zero exits.
+    public function provideRunIfCommandExistsFailures(): array
+    {
+        return [
+            'missing command' => ['definitely-not-real', []],
+            'failing command' => ['sh', ['-c', 'exit 7']],
+        ];
+    }
+
     // runWithEnv uses passthru, so we assert on the exit status to remain insensitive to stdout.
     public function testRunWithEnvInjectsEnvironmentVariables(): void
     {
-        $status = System::runWithEnv('sh', ['PING' => 'PONG'], ['-c', 'test "$PING" = "PONG"']);
+        $status = System::runWithEnv('sh', ['PING' => 'PONG', 'ALPHA' => 'BETA'], ['-c', 'test "$PING" = "PONG" -a "$ALPHA" = "BETA"']);
         $this->assertSame(0, $status);
     }
 
-    // isBlockDevice should reject files and paths that do not point to block device nodes.
+    // runWithEnv should handle callers that do not need any extra environment overrides.
+    public function testRunWithEnvHandlesEmptyEnvironment(): void
+    {
+        $status = System::runWithEnv('sh', [], ['-c', 'exit 0']);
+        $this->assertSame(0, $status);
+    }
+
+    // runWithEnv should allow callers to observe non-zero exits when requested.
+    public function testRunWithEnvReturnsStatusWhenFailureAllowed(): void
+    {
+        $status = System::runWithEnv('sh', ['PING' => 'PONG'], ['-c', 'exit 9'], true);
+        $this->assertSame(9, $status);
+    }
+
+    // runWithEnv should mirror run() by exiting when allowFailure is false and the command fails.
+    public function testRunWithEnvStopsOnFailureWhenDisallowed(): void
+    {
+        $environment = ['PING' => 'PONG'];
+        $args = ['-c', 'exit 4'];
+        [$output, $status] = $this->invokeSystemInIsolatedProcess(
+            sprintf('\\Lib\\Common\\System::runWithEnv(%s, %s, %s);', var_export('sh', true), var_export($environment, true), var_export($args, true))
+        );
+
+        $this->assertSame(4, $status);
+        $this->assertStringContainsString('[ERROR]', $output);
+        $this->assertStringContainsString('Command failed', $output);
+    }
+
+    // isBlockDevice should reject files, directories, and missing paths as non-block nodes.
     public function testIsBlockDeviceIdentifiesRegularFilesAsFalse(): void
     {
+        $tempFile = tempnam(sys_get_temp_dir(), 'mcx');
+        $this->assertIsString($tempFile);
+
+        $this->assertFalse(System::isBlockDevice($tempFile));
         $this->assertFalse(System::isBlockDevice(__FILE__));
+        $this->assertFalse(System::isBlockDevice(dirname(__FILE__)));
+        $this->assertFalse(System::isBlockDevice('/dev/null'));
         $this->assertFalse(System::isBlockDevice('/definitely/not/here'));
+
+        if (is_string($tempFile)) {
+            unlink($tempFile);
+        }
+    }
+
+    // invokeSystemInIsolatedProcess executes System helpers in a fresh PHP process for exit testing.
+    private function invokeSystemInIsolatedProcess(string $invocation): array
+    {
+        $script = sprintf(
+            'require_once %s; %s',
+            var_export($this->getBootstrapPath(), true),
+            $invocation
+        );
+
+        $output = System::capture([PHP_BINARY, '-d', 'display_errors=0', '-r', $script], $status);
+        return [$output, $status];
+    }
+
+    // getBootstrapPath resolves the autoloader so isolated processes find System and Logging classes.
+    private function getBootstrapPath(): string
+    {
+        $bootstrapPath = realpath(__DIR__ . '/../../bootstrap.php');
+        if ($bootstrapPath === false) {
+            $this->fail('Unable to resolve bootstrap path for isolated System calls.');
+        }
+
+        return $bootstrapPath;
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,22 +2,38 @@
 
 This repository keeps the PHPUnit configuration lightweight so the shared `Lib\\Common` helpers load through the small autoloader in `tests/bootstrap.php`.
 
+## Suite Structure
+
+* `Tests\\Lib\\Common\\LoggingTest` runs each logging helper in a fresh PHP process and checks for consistent timestamps, level tags, and formatting even when the input message becomes strange.
+* `Tests\\Lib\\Common\\SystemTest` drives the command helpers through both successful and failing scenarios, including exit-code assertions that run in isolated PHP processes so PHPUnit itself does not terminate.
+
 ## Prerequisites
 
 * PHP 8.1 or newer with the `pcntl` and `posix` extensions enabled.
 * [PHPUnit 9](https://phpunit.de/) installed either via Composer (`composer require --dev phpunit/phpunit`) or by downloading the PHAR (`wget https://phar.phpunit.de/phpunit-9.phar`).
+* Standard POSIX utilities such as `sh`, `env`, `true`, and `false` on the test host because the System helper coverage shells out to them directly.
 
 ## Running the Tests
 
 1. Ensure PHPUnit is on your `$PATH` or available as `./vendor/bin/phpunit` when using Composer.
-2. Execute the suite from the project root:
+2. Execute the suite from the project root with whichever PHPUnit binary you installed:
    ```bash
-   ./vendor/bin/phpunit --configuration tests/phpunit.xml.dist
+   php phpunit.phar --configuration tests/phpunit.xml.dist
    ```
-   *When using the PHAR directly, replace the command above with `php phpunit-9.phar --configuration tests/phpunit.xml.dist`.*
+   *When using Composer's binaries, replace the command above with `./vendor/bin/phpunit --configuration tests/phpunit.xml.dist`.*
 3. The tests intentionally assert on exit codes rather than stdout/stderr content because `System::run()` forwards output using `passthru`. This keeps the expectations stable across environments with different shell noise levels.
+
+### Focused Execution
+
+* To rerun only the System helper coverage, use `php phpunit.phar --configuration tests/phpunit.xml.dist --filter SystemTest`.
+* When adding new cases, keep the pattern of pairing each success scenario with a failure-mode counterpart so regressions surface quickly.
+
+### Exit-Handling Checks
+
+* Tests that confirm forced exits use `System::capture()` to spawn a secondary PHP interpreter. This allows PHPUnit to receive the resulting exit code and log output without aborting the main process.
+* If these tests begin failing with unexpected output, enable `-d display_errors=1` inside the helper script to inspect any additional PHP warnings emitted by the isolated run.
 
 ## Troubleshooting
 
 * If PHPUnit cannot locate classes, confirm the repository is cloned with its relative directory layout intact so `tests/bootstrap.php` can map the `Lib\\Common` namespace.
-* When commands like `sh` are missing, install your distribution's POSIX shell package or update the tests to target an equivalent binary available on your platform.
+* When commands like `sh`, `env`, `true`, or `false` are missing, install your distribution's POSIX shell package or update the tests to target equivalent binaries available on your platform.


### PR DESCRIPTION
## Summary
- add a dedicated CommonHelpersTest that drives the logging shims, exit helper, and command detection through varied success and failure datasets using isolated PHP processes
- extend coverage to readable-file validation and non-empty assertions, including scenarios for missing binaries, malformed paths, and label handling to reach 50 new test invocations

## Testing
- php phpunit.phar --configuration tests/phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68cef9426560832f9951364c9ff5c87a